### PR TITLE
feat(logging): add highlights to logHandler calls

### DIFF
--- a/packages/aws-api-gateway/src/mappers/http-api-event.mapper.ts
+++ b/packages/aws-api-gateway/src/mappers/http-api-event.mapper.ts
@@ -144,10 +144,11 @@ export class HttpApiEventMapper extends BaseApiEventMapper implements EventMappe
                 try {
                     body = JSON.stringify(body);
                 }
-                catch (e) {
+                catch (e: any) {
                     this.logHandler.error("HttpApiEventMapper: Could not convert the response body into a string by stringifying it as a JSON.", {
                         highlights: {
-                            body,
+                          errorMessage: e?.message ?? "Unknown error",
+                          body,
                         },
                         extra: {
                             error: e,

--- a/packages/aws-api-gateway/src/mappers/http-api-event.mapper.ts
+++ b/packages/aws-api-gateway/src/mappers/http-api-event.mapper.ts
@@ -146,9 +146,11 @@ export class HttpApiEventMapper extends BaseApiEventMapper implements EventMappe
                 }
                 catch (e) {
                     this.logHandler.error("HttpApiEventMapper: Could not convert the response body into a string by stringifying it as a JSON.", {
+                        highlights: {
+                            body,
+                        },
                         extra: {
                             error: e,
-                            body,
                         }
                     }, AwsApiGatewayModuleKeyname)
                 }

--- a/packages/aws-api-gateway/src/mappers/rest-api-event.mapper.ts
+++ b/packages/aws-api-gateway/src/mappers/rest-api-event.mapper.ts
@@ -140,9 +140,10 @@ export class RestApiEventMapper extends BaseApiEventMapper implements EventMappe
                 try {
                     body = JSON.stringify(body);
                 }
-                catch (e) {
+                catch (e: any) {
                     this.logHandler.error("RestApiEventMapper: Could not convert the response body into a string by stringifying it as a JSON.", {
                         highlights: {
+                            errorMessage: e?.message ?? "Unknown error",
                             body,
                         },
                         extra: {

--- a/packages/aws-api-gateway/src/mappers/rest-api-event.mapper.ts
+++ b/packages/aws-api-gateway/src/mappers/rest-api-event.mapper.ts
@@ -142,9 +142,11 @@ export class RestApiEventMapper extends BaseApiEventMapper implements EventMappe
                 }
                 catch (e) {
                     this.logHandler.error("RestApiEventMapper: Could not convert the response body into a string by stringifying it as a JSON.", {
+                        highlights: {
+                            body,
+                        },
                         extra: {
                             error: e,
-                            body,
                         }
                     }, AwsApiGatewayModuleKeyname)
                 }

--- a/packages/core/src/dispatchers/event.dispatcher.ts
+++ b/packages/core/src/dispatchers/event.dispatcher.ts
@@ -39,8 +39,10 @@ export class EventDispatcher implements EventDispatcherInterface {
      */
     async dispatch(event: Event<any>): Promise<EventResponse<any, any>> {
         this.logHandler.debug("EventDispatcher: Dispatching event.", {
-            extra: {
+            highlights: {
                 event,
+            },
+            extra: {
                 eventHandlers: this.eventHandlers,
                 eventHandlerNames: this.eventHandlers.map(eventHandler => eventHandler.constructor.name),
             }
@@ -62,10 +64,12 @@ export class EventDispatcher implements EventDispatcherInterface {
         for (const eventHandler of this.eventHandlers) {
             if(eventHandler.supports(event)) {
                 this.logHandler.debug("EventDispatcher: The EventHandler supports the event.", {
-                    extra: {
+                    highlights: {
                         event,
-                        eventHandler: eventHandler,
                         eventHandlerName: eventHandler.constructor.name,
+                    },
+                    extra: {
+                        eventHandler: eventHandler,
                     }
                 }, CoreModuleKeyname)
 
@@ -74,10 +78,12 @@ export class EventDispatcher implements EventDispatcherInterface {
             }
             else {
                 this.logHandler.debug("EventDispatcher: The EventHandler doesn't support the event.", {
-                    extra: {
+                    highlights: {
                         event,
-                        eventHandler: eventHandler,
                         eventHandlerName: eventHandler.constructor.name,
+                    },
+                    extra: {
+                        eventHandler: eventHandler,
                     }
                 }, CoreModuleKeyname)
             }
@@ -90,7 +96,7 @@ export class EventDispatcher implements EventDispatcherInterface {
         }
 
         this.logHandler.debug("EventDispatcher: Calling event handler.", {
-            extra: {
+            highlights: {
                 event,
             }
         })
@@ -99,7 +105,7 @@ export class EventDispatcher implements EventDispatcherInterface {
         const eventResponse = await supportingEventHandlers[0].handle(event);
 
         this.logHandler.debug("EventDispatcher: Called event handler.", {
-            extra: {
+            highlights: {
                 event,
                 eventResponse,
             }

--- a/packages/core/src/dispatchers/event.dispatcher.ts
+++ b/packages/core/src/dispatchers/event.dispatcher.ts
@@ -40,9 +40,10 @@ export class EventDispatcher implements EventDispatcherInterface {
     async dispatch(event: Event<any>): Promise<EventResponse<any, any>> {
         this.logHandler.debug("EventDispatcher: Dispatching event.", {
             highlights: {
-                event,
+                eventType: event.type,
             },
             extra: {
+                event,
                 eventHandlers: this.eventHandlers,
                 eventHandlerNames: this.eventHandlers.map(eventHandler => eventHandler.constructor.name),
             }
@@ -65,10 +66,11 @@ export class EventDispatcher implements EventDispatcherInterface {
             if(eventHandler.supports(event)) {
                 this.logHandler.debug("EventDispatcher: The EventHandler supports the event.", {
                     highlights: {
-                        event,
+                        eventType: event.type,
                         eventHandlerName: eventHandler.constructor.name,
                     },
                     extra: {
+                        event,
                         eventHandler: eventHandler,
                     }
                 }, CoreModuleKeyname)
@@ -79,10 +81,11 @@ export class EventDispatcher implements EventDispatcherInterface {
             else {
                 this.logHandler.debug("EventDispatcher: The EventHandler doesn't support the event.", {
                     highlights: {
-                        event,
+                        eventType: event.type,
                         eventHandlerName: eventHandler.constructor.name,
                     },
                     extra: {
+                        event,
                         eventHandler: eventHandler,
                     }
                 }, CoreModuleKeyname)
@@ -97,8 +100,11 @@ export class EventDispatcher implements EventDispatcherInterface {
 
         this.logHandler.debug("EventDispatcher: Calling event handler.", {
             highlights: {
+                eventType: event.type,
+            },
+            extra: {
                 event,
-            }
+          }
         })
 
         // We only support executing the handler with the highest priority.
@@ -106,6 +112,9 @@ export class EventDispatcher implements EventDispatcherInterface {
 
         this.logHandler.debug("EventDispatcher: Called event handler.", {
             highlights: {
+              eventType: event.type,
+            },
+            extra: {
                 event,
                 eventResponse,
             }

--- a/packages/core/src/kernel.ts
+++ b/packages/core/src/kernel.ts
@@ -96,7 +96,14 @@ export class Kernel {
 
         const logHandler: LogHandlerInterface = this.container.resolve("LogHandlerInterface");
 
-        logHandler.debug("Kernel: The Kernel was instantiated in '" + ((this.initializationSpan.endDate - this.initializationSpan.startDate) / 1000) + "' seconds.", {extra: {initializationSpan: this.initializationSpan}}, CoreModuleKeyname);
+        logHandler.debug("Kernel: The Kernel was instantiated in '" + ((this.initializationSpan.endDate - this.initializationSpan.startDate) / 1000) + "' seconds.", {
+            highlights: {
+                initializationTime: ((this.initializationSpan.endDate - this.initializationSpan.startDate) / 1000),
+            },
+            extra: {
+                initializationSpan: this.initializationSpan
+            }
+        }, CoreModuleKeyname);
     }
 
 

--- a/packages/security/src/managers/authorizer.manager.ts
+++ b/packages/security/src/managers/authorizer.manager.ts
@@ -52,14 +52,18 @@ export class AuthorizerManager implements AuthorizerManagerInterface {
                 const didAuthorize= await instantiatedGuard.isAuthorized(request, identity);
                 isAuthorized = isAuthorized && didAuthorize;
             }
-            catch (e) {
+            catch (e: any) {
                 this.logHandler.error("AuthorizerManager: Error while authorizing the request.", {
                     highlights: {
-                        request,
-                        identity,
+                        errorMessage: e?.message ?? "Unknown error",
+                        requestUrl: `${request.httpMethod} ${request.url}`,
+                        identityId: identity?.id ?? "No Identity Id found",
+                        identityClaims: identity?.claims ?? "No claims found",
                     },
                     extra: {
-                        error: e
+                        error: e,
+                        request,
+                        identity,
                     }
                 }, SecurityModuleKeyname);
                 isAuthorized = false;

--- a/packages/security/src/managers/authorizer.manager.ts
+++ b/packages/security/src/managers/authorizer.manager.ts
@@ -53,7 +53,15 @@ export class AuthorizerManager implements AuthorizerManagerInterface {
                 isAuthorized = isAuthorized && didAuthorize;
             }
             catch (e) {
-                this.logHandler.error("AuthorizerManager: Error while authorizing the request.", {extra: {error: e}}, SecurityModuleKeyname);
+                this.logHandler.error("AuthorizerManager: Error while authorizing the request.", {
+                    highlights: {
+                        request,
+                        identity,
+                    },
+                    extra: {
+                        error: e
+                    }
+                }, SecurityModuleKeyname);
                 isAuthorized = false;
             }
         }

--- a/packages/security/src/managers/permission.manager.ts
+++ b/packages/security/src/managers/permission.manager.ts
@@ -33,7 +33,7 @@ export class PermissionManager {
 
         if(this.voters.length === 0){
             this.logHandler.warning("PermissionManager: No voters were found, this could lead to unexpected behavior. Make sure that you have registered voters in your application.", {
-                extra: {
+                highlights: {
                     identity,
                     action,
                     resource,
@@ -45,7 +45,15 @@ export class PermissionManager {
 
         for(const voter of this.voters) {
             if(voter.supports(resource) === false) {
-                this.logHandler.debug("PermissionManager: voter does not support this resource.", {extra: {identity, action, resource, voter: voter.constructor.name}}, SecurityModuleKeyname );
+                this.logHandler.debug("PermissionManager: voter does not support this resource.", {
+                    highlights: {
+                        resource,
+                        voter: voter.constructor.name,
+                    },
+                    extra: {
+                        identity, action,
+                    }
+                }, SecurityModuleKeyname );
                 continue;
             }
 
@@ -55,15 +63,31 @@ export class PermissionManager {
                 const message = "PermissionManager: Voter " + voter.constructor.name + " voted: " + vote;
 
                 if(vote === VoteEnum.Deny) { // When it's being denied, it usually mean that something is important to be noticed.
-                    this.logHandler.info(message, {extra: {identity, action, resource, voter: voter.constructor.name}}, SecurityModuleKeyname)
+                    this.logHandler.info(message, {
+                        highlights: {
+                            identity, action, resource, voter: voter.constructor.name
+                        }
+                    }, SecurityModuleKeyname)
                 }
                  else {
-                    this.logHandler.debug(message, {extra: {identity, action, resource, voter: voter.constructor.name}}, SecurityModuleKeyname );
+                    this.logHandler.debug(message, {
+                        highlights: {
+                            identity, action, resource, voter: voter.constructor.name
+                        }
+                    }, SecurityModuleKeyname );
                 }
 
                 votes.push(vote);
             } catch (error) {
-                this.logHandler.error("PermissionManager: Error while voting, please check the logs for more details.", {extra: {error, resource, voter: voter.constructor.name}}, SecurityModuleKeyname);
+                this.logHandler.error("PermissionManager: Error while voting, please check the logs for more details.", {
+                    highlights: {
+                        resource,
+                        voter: voter.constructor.name,
+                    },
+                    extra: {
+                        error,
+                    }
+                }, SecurityModuleKeyname);
                 throw error;
             }
 
@@ -77,7 +101,14 @@ export class PermissionManager {
             }
         }
 
-        this.logHandler.info("PermissionManager: Access to resource " + resource.constructor.name + " was " + (shouldGrantAccess ? "GRANTED" : "DENIED"), {extra: {identity, action, resource}}, SecurityModuleKeyname);
+        this.logHandler.info("PermissionManager: Access to resource " + resource.constructor.name + " was " + (shouldGrantAccess ? "GRANTED" : "DENIED"), {
+            highlights: {
+                identity,
+                action,
+                resource,
+                access: shouldGrantAccess ? "GRANTED" : "DENIED",
+            }
+        }, SecurityModuleKeyname);
 
         return shouldGrantAccess;
     }

--- a/packages/security/src/managers/permission.manager.ts
+++ b/packages/security/src/managers/permission.manager.ts
@@ -34,9 +34,14 @@ export class PermissionManager {
         if(this.voters.length === 0){
             this.logHandler.warning("PermissionManager: No voters were found, this could lead to unexpected behavior. Make sure that you have registered voters in your application.", {
                 highlights: {
-                    identity,
+                    identityId: identity?.id ?? "No Identity Id found",
+                    identityClaims: identity?.claims ?? "No claims found",
                     action,
+                },
+                extra: {
+                    identity,
                     resource,
+                    votingStrategy,
                 }
             }, SecurityModuleKeyname);
         }
@@ -47,11 +52,15 @@ export class PermissionManager {
             if(voter.supports(resource) === false) {
                 this.logHandler.debug("PermissionManager: voter does not support this resource.", {
                     highlights: {
-                        resource,
+                        identityId: identity?.id ?? "No Identity Id found",
+                        identityClaims: identity?.claims ?? "No claims found",
+                        action,
                         voter: voter.constructor.name,
                     },
                     extra: {
-                        identity, action,
+                        identity,
+                        resource,
+                        votingStrategy,
                     }
                 }, SecurityModuleKeyname );
                 continue;
@@ -64,29 +73,53 @@ export class PermissionManager {
 
                 if(vote === VoteEnum.Deny) { // When it's being denied, it usually mean that something is important to be noticed.
                     this.logHandler.info(message, {
-                        highlights: {
-                            identity, action, resource, voter: voter.constructor.name
-                        }
+                      highlights: {
+                        identityId: identity?.id ?? "No Identity Id found",
+                        identityClaims: identity?.claims ?? "No claims found",
+                        action,
+                        voter: voter.constructor.name,
+                        vote,
+                      },
+                      extra: {
+                        identity,
+                        resource,
+                        votingStrategy,
+                      }
                     }, SecurityModuleKeyname)
                 }
                  else {
                     this.logHandler.debug(message, {
-                        highlights: {
-                            identity, action, resource, voter: voter.constructor.name
-                        }
+                      highlights: {
+                        identityId: identity?.id ?? "No Identity Id found",
+                        identityClaims: identity?.claims ?? "No claims found",
+                        action,
+                        voter: voter.constructor.name,
+                        vote,
+                      },
+                      extra: {
+                        identity,
+                        resource,
+                        votingStrategy,
+                      }
                     }, SecurityModuleKeyname );
                 }
 
                 votes.push(vote);
-            } catch (error) {
+            } catch (error: any) {
                 this.logHandler.error("PermissionManager: Error while voting, please check the logs for more details.", {
-                    highlights: {
-                        resource,
-                        voter: voter.constructor.name,
-                    },
-                    extra: {
-                        error,
-                    }
+                  highlights: {
+                    errorMessage: error.message ?? "Unknown error",
+                    identityId: identity?.id ?? "No Identity Id found",
+                    identityClaims: identity?.claims ?? "No claims found",
+                    action,
+                    voter: voter.constructor.name,
+                  },
+                  extra: {
+                    error,
+                    identity,
+                    resource,
+                    votingStrategy,
+                  }
                 }, SecurityModuleKeyname);
                 throw error;
             }
@@ -103,11 +136,15 @@ export class PermissionManager {
 
         this.logHandler.info("PermissionManager: Access to resource " + resource.constructor.name + " was " + (shouldGrantAccess ? "GRANTED" : "DENIED"), {
             highlights: {
-                identity,
-                action,
-                resource,
+                resourceName: resource.constructor.name,
                 access: shouldGrantAccess ? "GRANTED" : "DENIED",
-            }
+                identityId: identity?.id ?? "No Identity Id found",
+                identityClaims: identity?.claims ?? "No claims found",
+            }, extra: {
+                identity,
+                resource,
+                votingStrategy,
+          }
         }, SecurityModuleKeyname);
 
         return shouldGrantAccess;

--- a/packages/stripe/src/clients/stripe.client.ts
+++ b/packages/stripe/src/clients/stripe.client.ts
@@ -56,13 +56,15 @@ export class StripeClient implements StripeClientInterface{
 
         try {
             return this.getStripeClient().webhooks.constructEvent(request.rawBody, stripeSignature, stripeSigningEndpointSecret);
-        } catch (err) {
+        } catch (error: any) {
             this.logHandler.error("StripeClient: Error with stripe signature.", {
                 highlights: {
-                    request,
+                    errorMessage: error.message ?? "Unknown error",
+                    requestUrl: `${request.httpMethod} ${request.url}`,
                 },
                 extra: {
-                    error: err
+                    request,
+                    error,
                 }
             }, StripeModuleKeyname);
             throw new StripeAuthenticationError(400, 'Raw body does not match stripe signature');

--- a/packages/stripe/src/clients/stripe.client.ts
+++ b/packages/stripe/src/clients/stripe.client.ts
@@ -57,7 +57,14 @@ export class StripeClient implements StripeClientInterface{
         try {
             return this.getStripeClient().webhooks.constructEvent(request.rawBody, stripeSignature, stripeSigningEndpointSecret);
         } catch (err) {
-            this.logHandler.error("StripeClient: Error with stripe signature.", {extra: {error: err, request}}, StripeModuleKeyname);
+            this.logHandler.error("StripeClient: Error with stripe signature.", {
+                highlights: {
+                    request,
+                },
+                extra: {
+                    error: err
+                }
+            }, StripeModuleKeyname);
             throw new StripeAuthenticationError(400, 'Raw body does not match stripe signature');
         }
     }

--- a/packages/stripe/src/managers/stripe-webhooks.manager.ts
+++ b/packages/stripe/src/managers/stripe-webhooks.manager.ts
@@ -38,10 +38,13 @@ export class StripeWebhooksManager {
         if(!event.type.startsWith('customer.subscription')) {
             this.logHandler.error("StripeWebhooksManager: Stripe event is not a subscription, make sure to only send subscription events to this webhook.", {
                 highlights: {
-                    event,
+                    stripeEventId: event.id,
+                    requestUrl: `${request.httpMethod} ${request.url}`,
                 },
                 extra: {
-                    className: StripeWebhooksManager.name
+                    className: StripeWebhooksManager.name,
+                    request,
+                    event,
                 }
             }, StripeModuleKeyname);
             throw new Error("Event is not a subscription");
@@ -79,12 +82,15 @@ export class StripeWebhooksManager {
                 break;
             default:
                 await this.logHandler.debug("StripeWebhooksManager: This event type is not supported.", {
-                    highlights: {
-                        event,
-                    },
-                    extra: {
-                        className: StripeWebhooksManager.name
-                    }
+                  highlights: {
+                    stripeEventId: event.id,
+                    requestUrl: `${request.httpMethod} ${request.url}`,
+                  },
+                  extra: {
+                    className: StripeWebhooksManager.name,
+                    request,
+                    event,
+                  }
                 }, StripeModuleKeyname);
                 return Promise.resolve();
         }

--- a/packages/stripe/src/managers/stripe-webhooks.manager.ts
+++ b/packages/stripe/src/managers/stripe-webhooks.manager.ts
@@ -36,7 +36,14 @@ export class StripeWebhooksManager {
 
         // For the moment we only handle subscription events.
         if(!event.type.startsWith('customer.subscription')) {
-            this.logHandler.error("StripeWebhooksManager: Stripe event is not a subscription, make sure to only send subscription events to this webhook.", {extra: {event, className: StripeWebhooksManager.name}}, StripeModuleKeyname);
+            this.logHandler.error("StripeWebhooksManager: Stripe event is not a subscription, make sure to only send subscription events to this webhook.", {
+                highlights: {
+                    event,
+                },
+                extra: {
+                    className: StripeWebhooksManager.name
+                }
+            }, StripeModuleKeyname);
             throw new Error("Event is not a subscription");
         }
 
@@ -71,7 +78,14 @@ export class StripeWebhooksManager {
                 type = StripeEventTypeEnum.StripeSubscriptionPendingUpdateExpired
                 break;
             default:
-                await this.logHandler.debug("StripeWebhooksManager: This event type is not supported.", {extra: {event, className: StripeWebhooksManager.name}}, StripeModuleKeyname);
+                await this.logHandler.debug("StripeWebhooksManager: This event type is not supported.", {
+                    highlights: {
+                        event,
+                    },
+                    extra: {
+                        className: StripeWebhooksManager.name
+                    }
+                }, StripeModuleKeyname);
                 return Promise.resolve();
         }
 


### PR DESCRIPTION
This commit adds highlights to several `logHandler` calls to improve the debugging experience. By providing more context in the logs, it will be easier to identify the source of issues and understand the flow of data.

The following changes were made:

- Added `highlights` to `logHandler` calls in `http-api-event.mapper.ts` and `rest-api-event.mapper.ts` to log the body of the response when an error occurs.
- Added `highlights` to `logHandler` calls in `event.dispatcher.ts` to log the event being dispatched.
- Added `highlights` to `logHandler` calls in `kernel.ts` to log the initialization time.
- Added `highlights` to `logHandler` calls in `authorizer.manager.ts` to log the request and identity when an error occurs.
- Added `highlights` to `logHandler` calls in `permission.manager.ts` to log the identity, action, and resource when a warning or error occurs.
- Added `highlights` to `logHandler` calls in `stripe.client.ts` to log the request when an error occurs.
- Added `highlights` to `logHandler` calls in `stripe-webhooks.manager.ts` to log the event when an error occurs.