### PR TITLE
feat(networking): add unit and e2e tests for error response sanitizer

### DIFF
--- a/packages/networking/src/interceptors/error-response-sanitizer.request-interceptor.spec.ts
+++ b/packages/networking/src/interceptors/error-response-sanitizer.request-interceptor.spec.ts
@@ -1,0 +1,54 @@
+import 'reflect-metadata';
+import { ErrorResponseSanitizerRequestInterceptor } from './error-response-sanitizer.request-interceptor';
+import { Response } from '@pristine-ts/common';
+
+describe('ErrorResponseSanitizerRequestInterceptor', () => {
+  it('should remove stack, extra, and errors from the response body', async () => {
+    const interceptor = new ErrorResponseSanitizerRequestInterceptor(true);
+
+    const error = new Error('Test error');
+    const response = new Response();
+    response.body = {
+      message: 'An error occurred',
+      stack: 'Error stack trace',
+      extra: { details: 'Extra details' },
+      errors: ['Error 1', 'Error 2'],
+    };
+
+    const newResponse = await interceptor.interceptError(error, response, {} as any);
+
+    expect(newResponse.body).toEqual({
+      message: 'An error occurred',
+    });
+  });
+
+  it('should not modify the response body if it is not an object', async () => {
+    const interceptor = new ErrorResponseSanitizerRequestInterceptor(true);
+
+    const error = new Error('Test error');
+    const response = new Response();
+    response.body = 'Error message';
+
+    const newResponse = await interceptor.interceptError(error, response, {} as any);
+
+    expect(newResponse.body).toBe('Error message');
+  });
+
+  it('should not modify the response body if isActive is false', async () => {
+    const interceptor = new ErrorResponseSanitizerRequestInterceptor(false);
+
+    const error = new Error('Test error');
+    const response = new Response();
+    const body = {
+        message: 'An error occurred',
+        stack: 'Error stack trace',
+        extra: { details: 'Extra details' },
+        errors: ['Error 1', 'Error 2'],
+      };
+    response.body = body;
+
+    const newResponse = await interceptor.interceptError(error, response, {} as any);
+
+    expect(newResponse.body).toEqual(body);
+  });
+});

--- a/tests/e2e/scenarios/modules/networking/error-response-sanitizer.scenario.e2e.ts
+++ b/tests/e2e/scenarios/modules/networking/error-response-sanitizer.scenario.e2e.ts
@@ -1,0 +1,72 @@
+import {
+    Controller,
+    Get,
+    Request,
+    Response,
+    HttpMethod,
+    Route,
+    RequestInterface,
+    ResponseInterface
+} from "@pristine-ts/networking";
+import { AppModule, Kernel } from "@pristine-ts/core";
+import { inject, injectable } from "tsyringe";
+
+@Controller("/api/2.0")
+@injectable()
+export class TestController {
+    @Get("/error")
+    public error(): Response {
+        const response = new Response();
+        try {
+            throw new Error("This is a test error");
+        } catch (e) {
+            response.status = 500;
+            response.body = {
+                message: e.message,
+                stack: e.stack,
+            };
+
+            return response;
+        }
+    }
+}
+
+@AppModule({
+    importServices: [TestController],
+})
+export class TestModule {}
+
+describe("Networking - Error Response Sanitizer", () => {
+    it("should remove the stack trace from the error response", async () => {
+        const kernel = new Kernel();
+        await kernel.start(TestModule, {
+            "pristine.logging.consoleLoggerActivated": false,
+            "pristine.logging.fileLoggerActivated": false,
+        });
+
+        const request: RequestInterface = new Request(HttpMethod.Get, "/api/2.0/error");
+        const response: ResponseInterface = await kernel.handle(request);
+
+        expect(response.status).toBe(500);
+        expect(response.body).toBeDefined();
+        expect(response.body.message).toBe("This is a test error");
+        expect(response.body.stack).toBeUndefined();
+    });
+
+    it("should not remove the stack trace from the error response when the sanitizer is deactivated", async () => {
+        const kernel = new Kernel();
+        await kernel.start(TestModule, {
+            "pristine.logging.consoleLoggerActivated": false,
+            "pristine.logging.fileLoggerActivated": false,
+            "pristine.networking.error_response_sanitizer.is_active": false,
+        });
+
+        const request: RequestInterface = new Request(HttpMethod.Get, "/api/2.0/error");
+        const response: ResponseInterface = await kernel.handle(request);
+
+        expect(response.status).toBe(500);
+        expect(response.body).toBeDefined();
+        expect(response.body.message).toBe("This is a test error");
+        expect(response.body.stack).toBeDefined();
+    });
+});


### PR DESCRIPTION
Adds unit and e2e tests for the `ErrorResponseSanitizerRequestInterceptor` to ensure it properly removes stack traces from error responses.