### PR TITLE
chore(worktrees): add container-layout worktree tooling + docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,5 +51,35 @@ The monorepo contains several packages under `packages/`. Key packages include:
 *   Structure mirrors the framework's modularity.
 *   `getting-started/` contains the primary learning path.
 
+## 7. Parallel git worktrees
+
+Parallel tasks/agents use a **container layout**: a folder named after the repo holds the
+clone in `master/` and each worktree as a **flat sibling** named after its task/branch (a
+`/` in the branch becomes `-` in the dir name). `master/` is the anchor — it stays on
+`master` and owns the installed `node_modules`; worktrees are disposable.
+
+```
+pristine-ts/                    <- container (named after the repo)
+├── master/                     <- anchor checkout, stays on master
+├── improve-logging/            <- worktree (branch improve-logging)
+└── feature-x/                  <- worktree (branch feature/x)
+```
+
+Worktrees are the **recommended default** for parallel or substantial work; small one-off
+branches can still be done in `master/`. The default base branch is always `master`.
+
+**Create / remove:**
+
+```
+scripts/worktree-new.sh <task> [base]              # base defaults to master
+scripts/worktree-rm.sh  <task> [--force] [--delete-branch]
+```
+
+**Provisioning:** dependencies are **isolated per worktree** — creation runs `npm ci` in
+every dir with a `package.json` + `package-lock.json` (root first, so the root's
+`file:packages/*` links resolve before the per-package installs); then build with
+`npm run build`. Nothing else is shared from `master`: pristine-ts has no data dir, docker
+stack, or local `.env` to link.
+
 ---
 **Note:** This file is a living document for agents. Update it as you discover new patterns or requirements.

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Create a fully-provisioned git worktree for a parallel agent/task.
+#
+# Usage: scripts/worktree-new.sh <task-name> [base-branch]
+#   <task-name>    Worktree dir + new branch name (e.g. "improve-logging"). A "/" in the
+#                  name is flattened to "-" for the directory (feature/x -> feature-x).
+#   [base-branch]  Branch to fork from. Defaults to "master".
+#
+# Layout (container): the worktree is a flat sibling of the master checkout --
+#   <container>/<task-name>      e.g. .../pristine-ts/improve-logging
+# next to .../pristine-ts/master. See AGENTS.md > "Parallel git worktrees".
+#
+# Provisioning: each worktree gets isolated dependencies -- `npm ci` runs in every dir
+# that has a package.json + package-lock.json (root first, so the root's file:packages/*
+# links resolve before the per-package installs). Nothing else is shared from master:
+# pristine-ts has no data dir, docker stack, or local .env to link.
+#
+# Run from anywhere inside the repo (master/ or any existing worktree).
+#
+set -euo pipefail
+
+usage() { echo "Usage: $(basename "$0") <task-name> [base-branch]" >&2; exit 1; }
+
+TASK="${1:-}"
+BASE="${2:-master}"
+[ -n "$TASK" ] || usage
+
+if [ "$TASK" = "master" ]; then
+  echo "Error: 'master' is reserved for the primary checkout. Pick another task name." >&2
+  exit 1
+fi
+
+# Resolve the master checkout (owns the real .git) and its container, from any worktree.
+# git rev-parse --git-common-dir always points at the main worktree's .git.
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+MAIN_REPO="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+CONTAINER="$(cd "$(dirname "$MAIN_REPO")" && pwd)"
+
+# Keep the real branch name, but flatten "/" so feature/x -> dir feature-x.
+BRANCH="$TASK"
+SLUG="${TASK//\//-}"
+DEST="$CONTAINER/$SLUG"
+
+[ -e "$DEST" ] && { echo "Error: $DEST already exists." >&2; exit 1; }
+if git -C "$MAIN_REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "Error: branch '$BRANCH' already exists. Pick another name or delete it first." >&2
+  exit 1
+fi
+
+echo "==> Creating worktree $DEST (branch '$BRANCH' off '$BASE')"
+git -C "$MAIN_REPO" worktree add -b "$BRANCH" "$DEST" "$BASE"
+
+echo "==> Installing dependencies (isolated per worktree; root first)"
+# `npm ci` honours the committed lockfile; if a lockfile has drifted out of sync we fall
+# back to `npm install` rather than aborting the whole provision.
+find "$DEST" -name package-lock.json -not -path '*/node_modules/*' -not -path '*/dist/*' -print0 \
+  | xargs -0 -n1 dirname \
+  | awk '{ print length, $0 }' | sort -n | cut -d' ' -f2- \
+  | while IFS= read -r dir; do
+      rel="${dir#"$DEST"/}"; [ "$dir" = "$DEST" ] && rel="."
+      echo "    npm ci  $rel"
+      if ! ( cd "$dir" && npm ci --no-audit --no-fund ); then
+        echo "    (lockfile out of sync -- falling back to npm install in $rel)"
+        ( cd "$dir" && npm install --no-audit --no-fund )
+      fi
+    done
+
+cat <<EOF
+
+==> Worktree ready: $DEST
+    Branch: $BRANCH (off $BASE)
+    Build:  ( cd "$DEST" && npm run build )
+EOF

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Remove a worktree created by worktree-new.sh.
+#
+# Usage: scripts/worktree-rm.sh <task-name> [--force] [--delete-branch]
+#   --force          Remove even if the worktree has uncommitted changes.
+#   --delete-branch  Also delete the branch named <task-name>.
+#
+# Deletes only the worktree directory. The master checkout is never touched.
+#
+set -euo pipefail
+
+usage() { echo "Usage: $(basename "$0") <task-name> [--force] [--delete-branch]" >&2; exit 1; }
+
+TASK="${1:-}"
+[ -n "$TASK" ] || usage
+shift
+
+FORCE=""
+DELETE_BRANCH=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE="--force" ;;
+    --delete-branch) DELETE_BRANCH=1 ;;
+    *) echo "Unknown option: $arg" >&2; usage ;;
+  esac
+done
+
+# Resolve the master checkout + container the same way worktree-new.sh does.
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+MAIN_REPO="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+CONTAINER="$(cd "$(dirname "$MAIN_REPO")" && pwd)"
+# Match worktree-new.sh: the dir name flattens "/" to "-" (the branch keeps its real name).
+SLUG="${TASK//\//-}"
+DEST="$CONTAINER/$SLUG"
+
+echo "==> Removing worktree $DEST"
+git -C "$MAIN_REPO" worktree remove $FORCE "$DEST"
+
+if [ "$DELETE_BRANCH" -eq 1 ]; then
+  echo "==> Deleting branch $TASK"
+  git -C "$MAIN_REPO" branch -D "$TASK"
+fi
+
+echo "==> Done. The master checkout is untouched."


### PR DESCRIPTION
## What

Standardizes the parallel git-worktree workflow onto a **container layout**: `master/` is the anchor checkout and each task is a **flat sibling** worktree (dir slug = branch with `/` → `-`).

```
pristine-ts/            <- container
├── master/             <- anchor, stays on master, owns installed node_modules
├── improve-logging/    <- worktree
└── feature-x/          <- worktree (branch feature/x)
```

## Changes

- **`scripts/worktree-new.sh` / `worktree-rm.sh`** — create/remove worktrees in the container layout. Creation runs `npm ci` in every `package-lock.json` dir (root first, so the root's `file:packages/*` links resolve before per-package installs), with a graceful `npm install` fallback if a lockfile has drifted. Nothing else is shared from `master` — pristine-ts has no data dir, docker stack, or local `.env`.
- **`AGENTS.md`** — new "Parallel git worktrees" section documenting the layout, the scripts, and per-worktree provisioning.

Worktrees are documented as the **recommended default** for parallel/substantial work; small one-off branches can still be done in `master/`. Default base branch is always `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)