### PR TITLE
refactor(cli): replace @inquirer/prompts with native terminal prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ The monorepo contains several packages under `packages/`. Key packages include:
 *   **Role:** Handles all interactions with the standard output/input for CLI commands.
 *   **Requirement:** Must remain lightweight. Do not introduce heavy UI libraries like `inquirer` or `ora` unless absolutely necessary and approved. Implement features using native ANSI codes and `readline`.
 
+### Interactive prompts (`@pristine-ts/cli`)
+*   The CLI's interactive prompts are **fully native — no third-party prompt library** (the old `@inquirer/prompts` dependency was removed). Do not re-add one; extend the existing primitives instead.
+*   `CliPrompt` (`managers/cli-prompt.manager.ts`) is the prompt surface: `input` / `confirm` (line-based, via `readline/promises`), `select` (arrow-key menu) and `readSecret` (masked input). The last two read keystrokes through `TerminalKeyReader` (`managers/terminal-key-reader.manager.ts`), the single place that flips stdin into raw mode (restored in every exit path).
+*   `Ctrl+C` rejects every prompt with `PromptCancelledError` (exit code 130, `kind: UserError` so the reporter prints it cleanly); callers that treat cancellation as a normal branch catch it via `instanceof`.
+*   Raw bytes are decoded by the pure, unit-tested `TerminalKeyDecoder` (`utils/`); yes/no answers go through the shared `BooleanAnswerParser` (`utils/`), reused by `CommandParameterPrompter`.
+
 ### Command options & `@commandParameter` (`@pristine-ts/cli`)
 *   A command's flags are declared as a class (its `optionsType`) decorated with `@pristine-ts/class-validator` rules. `CommandArgumentResolver` maps argv onto an instance and validates it before `run()`.
 *   `@commandParameter({flag?, question?})` (property decorator) describes a single CLI parameter: `flag` rebinds it to a differently-named flag (default = the property name); `question` makes the CLI ask for it interactively when it's absent. Model a required-but-askable value as a normal **required** field carrying `@commandParameter({question})` — not as an optional field hand-checked inside `run()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17066,7 +17066,6 @@
       "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
-        "@inquirer/prompts": "^7.2.0",
         "@pristine-ts/common": "file:../common",
         "@pristine-ts/configuration": "file:../configuration",
         "@pristine-ts/core": "file:../core",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
-        "@inquirer/prompts": "^7.2.0",
         "@pristine-ts/common": "file:../common",
         "@pristine-ts/configuration": "file:../configuration",
         "@pristine-ts/core": "file:../core",
@@ -34,7 +33,7 @@
     },
     "../common": {
       "name": "@pristine-ts/common",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/metadata": "^1.0.16",
@@ -44,7 +43,7 @@
     },
     "../configuration": {
       "name": "@pristine-ts/configuration",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/common": "file:../common"
@@ -55,7 +54,7 @@
     },
     "../core": {
       "name": "@pristine-ts/core",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/common": "file:../common",
@@ -67,7 +66,7 @@
     },
     "../data-mapping": {
       "name": "@pristine-ts/data-mapping",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/common": "file:../common",
@@ -81,7 +80,7 @@
     },
     "../data-mapping-common": {
       "name": "@pristine-ts/data-mapping-common",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/class-validator": "^2.0.4",
@@ -93,7 +92,7 @@
     },
     "../file": {
       "name": "@pristine-ts/file",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/class-validator": "^2.0.4",
@@ -105,7 +104,7 @@
     },
     "../logging": {
       "name": "@pristine-ts/logging",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/common": "file:../common",
@@ -128,7 +127,7 @@
     },
     "../observability": {
       "name": "@pristine-ts/observability",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/common": "file:../common",
@@ -152,7 +151,7 @@
     },
     "../telemetry": {
       "name": "@pristine-ts/telemetry",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/common": "file:../common",
@@ -161,7 +160,7 @@
     },
     "../validation": {
       "name": "@pristine-ts/validation",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@pristine-ts/class-validator": "^2.0.4",
@@ -596,340 +595,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@pristine-ts/common": {
       "resolved": "../common",
       "link": true
@@ -979,69 +644,6 @@
       "resolved": "../validation",
       "link": true
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
-      "license": "MIT"
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
     "node_modules/esbuild": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
@@ -1083,115 +685,11 @@
         "@esbuild/win32-x64": "0.24.2"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     }
   },
   "dependencies": {
@@ -1370,165 +868,6 @@
       "dev": true,
       "optional": true
     },
-    "@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="
-    },
-    "@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
-      "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      }
-    },
-    "@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
-      }
-    },
-    "@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
-      "requires": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
-      }
-    },
-    "@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="
-    },
-    "@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      }
-    },
-    "@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      }
-    },
-    "@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
-      "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      }
-    },
-    "@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
-      "requires": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
-      }
-    },
-    "@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
-      "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
-      "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      }
-    },
-    "@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "requires": {}
-    },
     "@pristine-ts/common": {
       "version": "file:../common",
       "requires": {
@@ -1627,47 +966,6 @@
         "@pristine-ts/networking": "file:../networking"
       }
     },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="
-    },
-    "cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
     "esbuild": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
@@ -1701,71 +999,10 @@
         "@esbuild/win32-x64": "0.24.2"
       }
     },
-    "iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
-    },
     "reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@inquirer/prompts": "^7.2.0",
     "@pristine-ts/common": "file:../common",
     "@pristine-ts/configuration": "file:../configuration",
     "@pristine-ts/core": "file:../core",

--- a/packages/cli/src/bootstrap/build-staleness-prompt.ts
+++ b/packages/cli/src/bootstrap/build-staleness-prompt.ts
@@ -1,6 +1,7 @@
 import {injectable} from "tsyringe";
 import {BuildManifestStalenessEnum} from "./build-manifest-staleness.enum";
-import {DynamicImporter} from "./dynamic-importer";
+import {CliPrompt} from "../managers/cli-prompt.manager";
+import {PromptCancelledError} from "../errors/prompt-cancelled.error";
 
 /**
  * When the build manifest is stale (source edited, output missing, etc.), `AppModuleLoader`
@@ -15,7 +16,7 @@ import {DynamicImporter} from "./dynamic-importer";
 export class BuildStalenessPrompt {
   private readonly promptMessage: string = "Run `pristine build` now to refresh?";
 
-  constructor(private readonly dynamicImporter: DynamicImporter) {
+  constructor(private readonly cliPrompt: CliPrompt) {
   }
 
   isInteractive(): boolean {
@@ -50,17 +51,14 @@ export class BuildStalenessPrompt {
    * for cancellation (Ctrl+C). Caller decides what to do with each outcome.
    */
   async prompt(reason: BuildManifestStalenessEnum): Promise<boolean | undefined> {
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const confirm: (config: any) => Promise<boolean> = inquirer.confirm;
-
     try {
-      return await confirm({
-        message: `${this.describe(reason)}\n  ${this.promptMessage}`,
-        default: true,
-      });
-    } catch {
-      // @inquirer throws on Ctrl+C. Treat as a clean cancellation.
-      return undefined;
+      return await this.cliPrompt.confirm(`${this.describe(reason)}\n  ${this.promptMessage}`, true);
+    } catch (error) {
+      if (error instanceof PromptCancelledError) {
+        // Ctrl+C — treat as a clean cancellation so the caller can exit with the explanation.
+        return undefined;
+      }
+      throw error;
     }
   }
 }

--- a/packages/cli/src/bootstrap/init-prompt.ts
+++ b/packages/cli/src/bootstrap/init-prompt.ts
@@ -1,5 +1,5 @@
 import {injectable} from "tsyringe";
-import {DynamicImporter} from "./dynamic-importer";
+import {CliPrompt} from "../managers/cli-prompt.manager";
 
 /**
  * Answers the init flow needs to gather. Each field corresponds to one config value that
@@ -16,8 +16,8 @@ export interface InitAnswers {
 }
 
 /**
- * Interactive Q&A for `pristine init`. Lazy-loads `@inquirer/prompts` so the dep cost is
- * only paid when actually prompting (the same pattern as `BuildStalenessPrompt` uses).
+ * Interactive Q&A for `pristine init`. Prompts through {@link CliPrompt}, the CLI's native
+ * (no third-party dependency) terminal-prompt manager.
  *
  * Each method takes a "current value" so callers can pre-fill answers from CLI flags and
  * only prompt for the gaps. Returning the same value the user passed in is intentional —
@@ -31,7 +31,7 @@ export class InitPrompt {
   private readonly defaultTsconfig: string = "tsconfig.json";
   private readonly defaultFormat: "esm" | "cjs" | "both" = "esm";
 
-  constructor(private readonly dynamicImporter: DynamicImporter) {
+  constructor(private readonly cliPrompt: CliPrompt) {
   }
 
   isInteractive(): boolean {
@@ -40,66 +40,42 @@ export class InitPrompt {
 
   async askSourcePath(current: string | undefined): Promise<string> {
     if (current !== undefined) return current;
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const input: (config: any) => Promise<string> = inquirer.input;
-    return input({
-      message: "Where does your AppModule source file live?",
-      default: this.defaultSourcePath,
-    });
+    return this.cliPrompt.input("Where does your AppModule source file live?", this.defaultSourcePath);
   }
 
   async askOutputPath(current: string | undefined): Promise<string> {
     if (current !== undefined) return current;
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const input: (config: any) => Promise<string> = inquirer.input;
-    return input({
-      message: "Where should the compiled AppModule output land?",
-      default: this.defaultOutputPath,
-    });
+    return this.cliPrompt.input("Where should the compiled AppModule output land?", this.defaultOutputPath);
   }
 
   async askTsconfig(current: string | undefined): Promise<string> {
     if (current !== undefined) return current;
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const input: (config: any) => Promise<string> = inquirer.input;
-    return input({
-      message: "Which tsconfig should `pristine build` use?",
-      default: this.defaultTsconfig,
-    });
+    return this.cliPrompt.input("Which tsconfig should `pristine build` use?", this.defaultTsconfig);
   }
 
   async askFormat(current: "esm" | "cjs" | "both" | undefined): Promise<"esm" | "cjs" | "both"> {
     if (current !== undefined) return current;
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const select: (config: any) => Promise<"esm" | "cjs" | "both"> = inquirer.select;
-    return select({
-      message: "Which build format do you want?",
-      choices: [
+    return this.cliPrompt.select<"esm" | "cjs" | "both">(
+      "Which build format do you want?",
+      [
         {name: "esm  (modern, recommended)", value: "esm"},
         {name: "cjs  (CommonJS)", value: "cjs"},
         {name: "both (publish ESM + CJS)", value: "both"},
       ],
-      default: this.defaultFormat,
-    });
+      this.defaultFormat,
+    );
   }
 
   async askScaffoldSource(current: boolean | undefined, sourcePath: string): Promise<boolean> {
     if (current !== undefined) return current;
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const confirm: (config: any) => Promise<boolean> = inquirer.confirm;
-    return confirm({
-      message: `Scaffold a starter AppModule at ${sourcePath}?`,
-      default: true,
-    });
+    return this.cliPrompt.confirm(`Scaffold a starter AppModule at ${sourcePath}?`, true);
   }
 
   async askWritePackageScripts(current: boolean | undefined): Promise<boolean> {
     if (current !== undefined) return current;
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const confirm: (config: any) => Promise<boolean> = inquirer.confirm;
-    return confirm({
-      message: "Add `build`, `start`, `verify` scripts to package.json (only ones that don't already exist)?",
-      default: true,
-    });
+    return this.cliPrompt.confirm(
+      "Add `build`, `start`, `verify` scripts to package.json (only ones that don't already exist)?",
+      true,
+    );
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,8 @@ import {SourceHasher} from "./bootstrap/source-hasher";
 import {ConfigLoader} from "./config/config-loader";
 import {CliModule} from "./cli.module";
 import {CliErrorReporter} from "./reporters/cli-error.reporter";
+import {CliPrompt} from "./managers/cli-prompt.manager";
+import {TerminalKeyReader} from "./managers/terminal-key-reader.manager";
 
 /**
  * Boots the CLI: discovers the consumer's AppModule, starts the kernel, and dispatches
@@ -163,7 +165,8 @@ export class Cli {
     const sourceHasher = new SourceHasher();
     const buildManifestReader = new BuildManifestReader();
     const buildManifestChecker = new BuildManifestChecker(sourceHasher);
-    const buildStalenessPrompt = new BuildStalenessPrompt(dynamicImporter);
+    const cliPrompt = new CliPrompt(new TerminalKeyReader());
+    const buildStalenessPrompt = new BuildStalenessPrompt(cliPrompt);
     const buildRunner = new BuildRunner();
     return new AppModuleLoader(
       configLoader,

--- a/packages/cli/src/enums/enums.ts
+++ b/packages/cli/src/enums/enums.ts
@@ -1,1 +1,2 @@
 export * from "./cli-decorator-metadata-keyname.enum";
+export * from "./terminal-key-name.enum";

--- a/packages/cli/src/enums/terminal-key-name.enum.ts
+++ b/packages/cli/src/enums/terminal-key-name.enum.ts
@@ -1,0 +1,16 @@
+/**
+ * The kinds of keypress the CLI's interactive prompts understand. `TerminalKeyDecoder`
+ * maps the raw bytes Node delivers from a raw-mode stdin onto one of these; every printable
+ * keystroke collapses to `Character` (with the literal character carried separately on
+ * {@link TerminalKey}). `Other` covers control/escape sequences the prompts don't act on
+ * (function keys, unhandled arrows) so callers can ignore them instead of echoing garbage.
+ */
+export enum TerminalKeyName {
+  Up = "up",
+  Down = "down",
+  Enter = "enter",
+  Backspace = "backspace",
+  CtrlC = "ctrl-c",
+  Character = "character",
+  Other = "other",
+}

--- a/packages/cli/src/errors/cli-error-code.enum.ts
+++ b/packages/cli/src/errors/cli-error-code.enum.ts
@@ -15,4 +15,10 @@ export enum CliErrorCode {
    * A programming error in the command's options definition, not bad user input.
    */
   CommandParameterFlagConflict = "COMMAND_PARAMETER_FLAG_CONFLICT",
+
+  /**
+   * The user cancelled an interactive prompt with `Ctrl+C`. Carried by
+   * `PromptCancelledError` — a clean, user-initiated cancellation, not a failure.
+   */
+  PromptCancelled = "PROMPT_CANCELLED",
 }

--- a/packages/cli/src/errors/errors.ts
+++ b/packages/cli/src/errors/errors.ts
@@ -1,2 +1,3 @@
 export * from "./cli-error-code.enum";
 export * from "./command-not-found.error";
+export * from "./prompt-cancelled.error";

--- a/packages/cli/src/errors/prompt-cancelled.error.ts
+++ b/packages/cli/src/errors/prompt-cancelled.error.ts
@@ -1,0 +1,21 @@
+import {PristineError, PristineErrorKind} from "@pristine-ts/common";
+import {CliErrorCode} from "./cli-error-code.enum";
+
+/**
+ * Thrown when the user cancels an interactive prompt with `Ctrl+C`. A clean, user-initiated
+ * cancellation — not a crash — so it carries `kind: UserError` (the `CliErrorReporter`
+ * renders the message verbatim instead of a stack dump) and exit code `130`, following the
+ * POSIX `128 + SIGINT(2)` convention so shell pipelines can detect the interrupt.
+ *
+ * Callers that treat cancellation as a normal branch (e.g. `BuildStalenessPrompt`) catch it
+ * via `instanceof`; everywhere else it propagates to the reporter for a tidy exit.
+ */
+export class PromptCancelledError extends PristineError {
+  public constructor() {
+    super("Prompt cancelled.", {
+      code: CliErrorCode.PromptCancelled,
+      exitCode: 130,
+      kind: PristineErrorKind.UserError,
+    });
+  }
+}

--- a/packages/cli/src/event-handlers/cli.event-handler.spec.ts
+++ b/packages/cli/src/event-handlers/cli.event-handler.spec.ts
@@ -15,7 +15,7 @@ import {CommandArgumentResolver} from "../services/command-argument-resolver";
 import {CommandOptionsResolver} from "../services/command-options-resolver";
 import {CommandParameterPrompter} from "../services/command-parameter-prompter";
 import {CliPrompt} from "../managers/cli-prompt.manager";
-import {DynamicImporter} from "../bootstrap/dynamic-importer";
+import {TerminalKeyReader} from "../managers/terminal-key-reader.manager";
 
 /**
  * Builds a `DataMapper` with the same normalizers `DataMappingModule` ships, so the
@@ -80,7 +80,7 @@ class CapturingLogHandler {
 const buildHandler = (): {handler: CliEventHandler; logHandler: CapturingLogHandler} => {
   const captured = new CapturingLogHandler();
   const validator = new Validator();
-  const prompter = new CommandParameterPrompter(new CliPrompt(new DynamicImporter()), {writeLine: (): void => {}} as any, validator, buildDataMapper(), false);
+  const prompter = new CommandParameterPrompter(new CliPrompt(new TerminalKeyReader()), {writeLine: (): void => {}} as any, validator, buildDataMapper(), false);
   const optionsResolver = new CommandOptionsResolver(validator, buildDataMapper(), prompter);
   const handler = new CliEventHandler(
     captured as any,

--- a/packages/cli/src/interfaces/interfaces.ts
+++ b/packages/cli/src/interfaces/interfaces.ts
@@ -1,1 +1,2 @@
 export * from "./command.interface";
+export * from "./terminal-key.interface";

--- a/packages/cli/src/interfaces/terminal-key.interface.ts
+++ b/packages/cli/src/interfaces/terminal-key.interface.ts
@@ -1,0 +1,12 @@
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+
+/**
+ * A single decoded keypress from an interactive terminal. `name` classifies the key;
+ * `sequence` is the raw character(s) it produced — meaningful for `Character` keys (the
+ * literal typed character, echoed/accumulated by callers) and retained for the rest for
+ * diagnostics.
+ */
+export interface TerminalKey {
+  name: TerminalKeyName;
+  sequence: string;
+}

--- a/packages/cli/src/managers/cli-prompt.manager.spec.ts
+++ b/packages/cli/src/managers/cli-prompt.manager.spec.ts
@@ -1,24 +1,146 @@
 import "reflect-metadata";
 import {CliPrompt} from "./cli-prompt.manager";
-import {DynamicImporter} from "../bootstrap/dynamic-importer";
+import {TerminalKeyReader} from "./terminal-key-reader.manager";
+import {TerminalKey} from "../interfaces/terminal-key.interface";
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+
+const character = (value: string): TerminalKey => ({name: TerminalKeyName.Character, sequence: value});
+const ENTER: TerminalKey = {name: TerminalKeyName.Enter, sequence: "\r"};
+const UP: TerminalKey = {name: TerminalKeyName.Up, sequence: "\x1b[A"};
+const DOWN: TerminalKey = {name: TerminalKeyName.Down, sequence: "\x1b[B"};
+const BACKSPACE: TerminalKey = {name: TerminalKeyName.Backspace, sequence: "\x7f"};
+
+/**
+ * Replays a scripted sequence of keys into a `read` handler, resolving as soon as the
+ * handler calls its `resolve` callback — the raw-mode reads (`select`, `readSecret`) can be
+ * tested without a real TTY by injecting this in place of `TerminalKeyReader`.
+ */
+class FakeTerminalKeyReader {
+  constructor(private readonly keys: TerminalKey[] = []) {
+  }
+
+  isInteractive(): boolean {
+    return true;
+  }
+
+  read<T>(onKey: (key: TerminalKey, resolve: (value: T) => void) => void): Promise<T> {
+    return new Promise<T>((resolve) => {
+      for (const key of this.keys) {
+        let resolved = false;
+        onKey(key, (value: T) => {
+          resolved = true;
+          resolve(value);
+        });
+        if (resolved) {
+          return;
+        }
+      }
+    });
+  }
+}
+
+const build = (keys: TerminalKey[] = []): CliPrompt =>
+  new CliPrompt(new FakeTerminalKeyReader(keys) as unknown as TerminalKeyReader);
 
 describe("CliPrompt", () => {
-  it("read delegates to process.stdin.read", () => {
-    const prompt = new CliPrompt(new DynamicImporter());
-    const spy = jest.spyOn(process.stdin, "read").mockReturnValue("buffered" as any);
-    expect(prompt.read()).toBe("buffered");
-    spy.mockRestore();
+  beforeEach(() => {
+    // Silence (and avoid asserting on) the ANSI redraws the prompts write while running.
+    jest.spyOn(process.stdout, "write").mockReturnValue(true);
   });
 
-  it("readSecret masks input via @inquirer/prompts' password, lazy-loaded through the importer", async () => {
-    const password = jest.fn().mockResolvedValue("hunter2");
-    const importer = {import: jest.fn().mockResolvedValue({password})} as unknown as DynamicImporter;
-    const prompt = new CliPrompt(importer);
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    const answer = await prompt.readSecret("Database password? ");
+  it("read delegates to process.stdin.read", () => {
+    const prompt = build();
+    jest.spyOn(process.stdin, "read").mockReturnValue("buffered" as any);
+    expect(prompt.read()).toBe("buffered");
+  });
 
-    expect(importer.import).toHaveBeenCalledWith("@inquirer/prompts");
-    expect(password).toHaveBeenCalledWith(expect.objectContaining({message: "Database password? "}));
-    expect(answer).toBe("hunter2");
+  describe("input", () => {
+    it("returns the typed answer, trimmed", async () => {
+      const prompt = build();
+      jest.spyOn(prompt, "readLine").mockResolvedValue("  src/app.ts  ");
+      expect(await prompt.input("Where?", "default.ts")).toBe("src/app.ts");
+    });
+
+    it("returns the default when the answer is empty", async () => {
+      const prompt = build();
+      jest.spyOn(prompt, "readLine").mockResolvedValue("");
+      expect(await prompt.input("Where?", "default.ts")).toBe("default.ts");
+    });
+  });
+
+  describe("confirm", () => {
+    it("returns the default on an empty answer", async () => {
+      const prompt = build();
+      jest.spyOn(prompt, "readLine").mockResolvedValue("");
+      expect(await prompt.confirm("Sure?", true)).toBe(true);
+      expect(await prompt.confirm("Sure?", false)).toBe(false);
+    });
+
+    it("parses yes and no answers", async () => {
+      const prompt = build();
+      const readLine = jest.spyOn(prompt, "readLine");
+      readLine.mockResolvedValueOnce("yes");
+      expect(await prompt.confirm("?", false)).toBe(true);
+      readLine.mockResolvedValueOnce("n");
+      expect(await prompt.confirm("?", true)).toBe(false);
+    });
+
+    it("re-asks until a recognized answer is given", async () => {
+      const prompt = build();
+      const readLine = jest.spyOn(prompt, "readLine")
+        .mockResolvedValueOnce("maybe")
+        .mockResolvedValueOnce("y");
+      expect(await prompt.confirm("?", true)).toBe(true);
+      expect(readLine).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("select", () => {
+    const choices = [
+      {name: "esm", value: "esm"},
+      {name: "cjs", value: "cjs"},
+      {name: "both", value: "both"},
+    ];
+
+    it("returns the highlighted choice after navigating down", async () => {
+      const prompt = build([DOWN, DOWN, ENTER]);
+      expect(await prompt.select("Format?", choices, "esm")).toBe("both");
+    });
+
+    it("starts the highlight on the default choice", async () => {
+      const prompt = build([ENTER]);
+      expect(await prompt.select("Format?", choices, "cjs")).toBe("cjs");
+    });
+
+    it("wraps around when moving up from the first choice", async () => {
+      const prompt = build([UP, ENTER]);
+      expect(await prompt.select("Format?", choices, "esm")).toBe("both");
+    });
+
+    it("throws when given no choices", async () => {
+      const prompt = build();
+      await expect(prompt.select("Format?", [])).rejects.toThrow();
+    });
+  });
+
+  describe("readSecret", () => {
+    it("accumulates characters and returns the value on Enter", async () => {
+      const prompt = build([character("h"), character("i"), ENTER]);
+      expect(await prompt.readSecret("Password? ")).toBe("hi");
+    });
+
+    it("erases the last character on Backspace", async () => {
+      const prompt = build([character("a"), character("b"), BACKSPACE, character("c"), ENTER]);
+      expect(await prompt.readSecret("Password? ")).toBe("ac");
+    });
+
+    it("does not trim the secret", async () => {
+      const prompt = build([character(" "), character("x"), ENTER]);
+      expect(await prompt.readSecret("Password? ")).toBe(" x");
+    });
   });
 });

--- a/packages/cli/src/managers/cli-prompt.manager.ts
+++ b/packages/cli/src/managers/cli-prompt.manager.ts
@@ -2,19 +2,36 @@ import {injectable} from "tsyringe";
 import {moduleScoped} from "@pristine-ts/common";
 import {CliModuleKeyname} from "../cli.module.keyname";
 import * as readline from "node:readline/promises";
-import {moveCursor, clearLine} from "node:readline";
+import {moveCursor, clearLine, cursorTo} from "node:readline";
 import {stdin as input, stdout as output} from "node:process";
 import {ConsoleReadlineOptions} from "../options/console-readline.options";
-import {DynamicImporter} from "../bootstrap/dynamic-importer";
+import {TerminalKeyReader} from "./terminal-key-reader.manager";
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+import {BooleanAnswerParser} from "../utils/boolean-answer-parser";
+import {PromptCancelledError} from "../errors/prompt-cancelled.error";
 
 /**
- * Interactive stdin reader for CLI commands. Wraps Node's `readline/promises` and offers
- * a single `readLine` method with optional masking after input is received.
+ * Interactive terminal prompts for CLI commands, implemented entirely on Node's `readline`
+ * and raw-mode stdin — no third-party prompt library. Line-based prompts (`readLine`,
+ * `input`, `confirm`) go through `readline/promises`; the keystroke-level prompts (`select`
+ * arrow menu, masked `readSecret`) go through {@link TerminalKeyReader}.
+ *
+ * `Ctrl+C` rejects with {@link PromptCancelledError} across all of them — the line prompts
+ * via a `readline` SIGINT handler, the raw-mode prompts via the key reader — so callers get
+ * one consistent cancellation signal.
  */
 @injectable()
 @moduleScoped(CliModuleKeyname)
 export class CliPrompt {
-  constructor(private readonly dynamicImporter: DynamicImporter) {
+  // ANSI constants, matching the conventions used by CliSpinner / CliProgressBar.
+  private static readonly CYAN = "\x1b[36m";
+  private static readonly DIM = "\x1b[2m";
+  private static readonly RESET = "\x1b[0m";
+  private static readonly HIDE_CURSOR = "\x1B[?25l";
+  private static readonly SHOW_CURSOR = "\x1B[?25h";
+  private static readonly POINTER = "❯";
+
+  constructor(private readonly terminalKeyReader: TerminalKeyReader) {
   }
 
   /**
@@ -28,40 +45,165 @@ export class CliPrompt {
   /**
    * Reads a line from stdin after displaying a prompt. When
    * `options.showCharactersOnTyping` is false, the answered line is cleared and replaced
-   * with a masked echo so the typed value isn't left visible on screen.
+   * with a masked echo so the typed value isn't left visible on screen (a post-input clear,
+   * not true keystroke suppression — use {@link readSecret} for real masking).
    *
-   * Note: this is not a true keystroke-suppressing password input — Node's stock
-   * `readline` does not support that without raw-mode handling. The current behavior is
-   * a post-input clear, sufficient for most CLI prompts.
+   * `Ctrl+C` rejects with {@link PromptCancelledError}: registering a `SIGINT` listener on
+   * the readline interface overrides Node's default interrupt handling, turning it into a
+   * clean rejection rather than a hung promise.
    */
   async readLine(question: string, options: ConsoleReadlineOptions = new ConsoleReadlineOptions()): Promise<string> {
     const rl = readline.createInterface({input, output});
 
-    const answer = await rl.question(question);
+    try {
+      const answer = await new Promise<string>((resolve, reject) => {
+        rl.on("SIGINT", () => reject(new PromptCancelledError()));
+        rl.question(question).then(resolve, reject);
+      });
 
-    if (!options.showCharactersOnTyping) {
-      moveCursor(output, 0, -1);
-      clearLine(output, 0);
-      process.stdout.write(`${question} [******]\n`);
+      if (!options.showCharactersOnTyping) {
+        moveCursor(output, 0, -1);
+        clearLine(output, 0);
+        process.stdout.write(`${question} [******]\n`);
+      }
+
+      return answer;
+    } finally {
+      rl.close();
     }
+  }
 
-    rl.close();
+  /**
+   * Asks a free-text question, optionally with a default. The default is shown as a hint and
+   * returned verbatim when the user submits an empty line. The answer is trimmed.
+   */
+  async input(message: string, defaultValue?: string): Promise<string> {
+    const suffix = defaultValue !== undefined && defaultValue !== ""
+      ? ` ${CliPrompt.DIM}(${defaultValue})${CliPrompt.RESET}`
+      : "";
 
+    const answer = (await this.readLine(`${message}${suffix} `)).trim();
+    if (answer.length === 0 && defaultValue !== undefined) {
+      return defaultValue;
+    }
     return answer;
   }
 
   /**
-   * Reads a secret (password, token, …) from stdin with the typed characters masked.
-   *
-   * Backed by `@inquirer/prompts`' `password` prompt — already a CLI dependency, used by
-   * `pristine init` — lazy-loaded through `DynamicImporter` so it stays out of the static
-   * bundle graph. Node's stock `readline` can't suppress echo without raw-mode handling, so
-   * this is the masked-input path until it's reimplemented natively. Isolating the inquirer
-   * call here keeps that future swap to a single method.
+   * Asks a yes/no question. An empty answer takes the default; anything `BooleanAnswerParser`
+   * understands (`y`/`yes`/`true`/`1`, `n`/`no`/`false`/`0`) is accepted; anything else is
+   * re-asked. The default is shown capitalized in the `(Y/n)` / `(y/N)` hint.
+   */
+  async confirm(message: string, defaultValue: boolean = true): Promise<boolean> {
+    const hint = defaultValue ? "(Y/n)" : "(y/N)";
+
+    for (; ;) {
+      const raw = (await this.readLine(`${message} ${hint} `)).trim();
+      if (raw.length === 0) {
+        return defaultValue;
+      }
+
+      const parsed = BooleanAnswerParser.parse(raw);
+      if (parsed !== undefined) {
+        return parsed;
+      }
+
+      process.stdout.write("Please answer yes (y) or no (n).\n");
+    }
+  }
+
+  /**
+   * Presents an arrow-key menu and returns the chosen choice's `value`. `↑`/`↓` move the
+   * highlight (wrapping at the ends), `Enter` selects, `Ctrl+C` cancels. When `defaultValue`
+   * matches a choice, the menu starts on it. The cursor is hidden while the menu is active
+   * and restored afterward.
+   */
+  async select<T>(message: string, choices: {name: string; value: T}[], defaultValue?: T): Promise<T> {
+    if (choices.length === 0) {
+      throw new Error("CliPrompt.select requires at least one choice.");
+    }
+
+    const defaultIndex = choices.findIndex((choice) => choice.value === defaultValue);
+    let active = defaultIndex >= 0 ? defaultIndex : 0;
+
+    process.stdout.write(CliPrompt.HIDE_CURSOR);
+    process.stdout.write(`${CliPrompt.CYAN}?${CliPrompt.RESET} ${message}\n`);
+    this.renderChoices(choices, active);
+
+    try {
+      return await this.terminalKeyReader.read<T>((key, resolve) => {
+        if (key.name === TerminalKeyName.Up) {
+          active = (active - 1 + choices.length) % choices.length;
+          this.repaintChoices(choices, active);
+        } else if (key.name === TerminalKeyName.Down) {
+          active = (active + 1) % choices.length;
+          this.repaintChoices(choices, active);
+        } else if (key.name === TerminalKeyName.Enter) {
+          resolve(choices[active].value);
+        }
+      });
+    } finally {
+      process.stdout.write(CliPrompt.SHOW_CURSOR);
+    }
+  }
+
+  /**
+   * Reads a secret (password, token, …) from stdin with the typed characters masked as `*`.
+   * Real keystroke suppression via raw mode (unlike {@link readLine}'s post-input clear):
+   * each character echoes a `*`, `Backspace` erases one, `Enter` submits, `Ctrl+C` cancels.
+   * The value is returned untrimmed — a secret may legitimately contain surrounding
+   * whitespace.
    */
   async readSecret(question: string): Promise<string> {
-    const inquirer = await this.dynamicImporter.import("@inquirer/prompts");
-    const password: (config: {message: string; mask?: boolean | string}) => Promise<string> = inquirer.password;
-    return password({message: question, mask: "*"});
+    process.stdout.write(question);
+
+    let value = "";
+    try {
+      await this.terminalKeyReader.read<void>((key, resolve) => {
+        if (key.name === TerminalKeyName.Enter) {
+          resolve(undefined);
+        } else if (key.name === TerminalKeyName.Backspace) {
+          if (value.length > 0) {
+            value = value.slice(0, -1);
+            process.stdout.write("\b \b");
+          }
+        } else if (key.name === TerminalKeyName.Character) {
+          value += key.sequence;
+          process.stdout.write("*");
+        }
+      });
+    } finally {
+      process.stdout.write("\n");
+    }
+
+    return value;
+  }
+
+  /**
+   * Writes the choice rows, highlighting the active one with a colored pointer. Each row is
+   * cleared before it's written so a repaint never leaves a longer previous label behind.
+   * @private
+   */
+  private renderChoices<T>(choices: {name: string; value: T}[], active: number): void {
+    choices.forEach((choice, index) => {
+      clearLine(process.stdout, 0);
+      cursorTo(process.stdout, 0);
+
+      if (index === active) {
+        process.stdout.write(`${CliPrompt.CYAN}${CliPrompt.POINTER} ${choice.name}${CliPrompt.RESET}\n`);
+      } else {
+        process.stdout.write(`  ${choice.name}\n`);
+      }
+    });
+  }
+
+  /**
+   * Moves the cursor back up over the previously-rendered choice rows and rewrites them, so
+   * the menu updates in place as the selection moves.
+   * @private
+   */
+  private repaintChoices<T>(choices: {name: string; value: T}[], active: number): void {
+    moveCursor(process.stdout, 0, -choices.length);
+    this.renderChoices(choices, active);
   }
 }

--- a/packages/cli/src/managers/managers.ts
+++ b/packages/cli/src/managers/managers.ts
@@ -2,4 +2,5 @@ export * from "./cli-output.manager";
 export * from "./cli-progress-bar.manager";
 export * from "./cli-prompt.manager";
 export * from "./cli-spinner.manager";
+export * from "./terminal-key-reader.manager";
 export * from "./shell.manager";

--- a/packages/cli/src/managers/terminal-key-reader.manager.spec.ts
+++ b/packages/cli/src/managers/terminal-key-reader.manager.spec.ts
@@ -1,0 +1,96 @@
+import "reflect-metadata";
+import {EventEmitter} from "node:events";
+import {TerminalKeyReader} from "./terminal-key-reader.manager";
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+import {PromptCancelledError} from "../errors/prompt-cancelled.error";
+
+/**
+ * Minimal stand-in for `process.stdin`: an EventEmitter with the TTY/raw-mode surface
+ * `TerminalKeyReader` touches, so reads can be driven with synthetic `data` events.
+ */
+class FakeInput extends EventEmitter {
+  isTTY = true;
+  isRaw = false;
+  setRawMode = jest.fn((mode: boolean) => {
+    this.isRaw = mode;
+    return this as any;
+  });
+  resume = jest.fn();
+  pause = jest.fn();
+}
+
+const buildReader = (): {reader: TerminalKeyReader; fakeInput: FakeInput} => {
+  const reader = new TerminalKeyReader();
+  const fakeInput = new FakeInput();
+  reader.input = fakeInput as any;
+  reader.output = {write: jest.fn()} as any;
+  return {reader, fakeInput};
+};
+
+describe("TerminalKeyReader", () => {
+  it("enters raw mode, decodes keys, resolves, then restores raw mode and removes the listener", async () => {
+    const {reader, fakeInput} = buildReader();
+    const seen: TerminalKeyName[] = [];
+
+    const promise = reader.read<string>((key, resolve) => {
+      seen.push(key.name);
+      if (key.name === TerminalKeyName.Enter) {
+        resolve("done");
+      }
+    });
+
+    fakeInput.emit("data", Buffer.from("a"));
+    fakeInput.emit("data", Buffer.from("\r"));
+
+    await expect(promise).resolves.toBe("done");
+    expect(seen).toEqual([TerminalKeyName.Character, TerminalKeyName.Enter]);
+    expect(fakeInput.setRawMode).toHaveBeenCalledWith(true);
+    expect(fakeInput.setRawMode).toHaveBeenLastCalledWith(false);
+    expect(fakeInput.listenerCount("data")).toBe(0);
+  });
+
+  it("rejects with PromptCancelledError on Ctrl+C without forwarding it to the handler", async () => {
+    const {reader, fakeInput} = buildReader();
+    const onKey = jest.fn();
+
+    const promise = reader.read(onKey);
+    fakeInput.emit("data", Buffer.from("\x03"));
+
+    await expect(promise).rejects.toBeInstanceOf(PromptCancelledError);
+    expect(onKey).not.toHaveBeenCalled();
+    expect(fakeInput.setRawMode).toHaveBeenLastCalledWith(false);
+  });
+
+  it("restores the terminal's prior raw state rather than a hardcoded false", async () => {
+    const {reader, fakeInput} = buildReader();
+    fakeInput.isRaw = true;
+
+    const promise = reader.read<string>((_key, resolve) => resolve("x"));
+    fakeInput.emit("data", Buffer.from("a"));
+
+    await promise;
+    expect(fakeInput.setRawMode).toHaveBeenLastCalledWith(true);
+  });
+
+  it("rejects and restores the terminal when the handler throws", async () => {
+    const {reader, fakeInput} = buildReader();
+
+    const promise = reader.read(() => {
+      throw new Error("boom");
+    });
+    fakeInput.emit("data", Buffer.from("a"));
+
+    await expect(promise).rejects.toThrow("boom");
+    expect(fakeInput.setRawMode).toHaveBeenLastCalledWith(false);
+    expect(fakeInput.listenerCount("data")).toBe(0);
+  });
+
+  it("reports interactivity from the stream TTY flags", () => {
+    const {reader, fakeInput} = buildReader();
+    reader.output = {isTTY: true, write: jest.fn()} as any;
+    expect(reader.isInteractive()).toBe(true);
+
+    fakeInput.isTTY = false;
+    expect(reader.isInteractive()).toBe(false);
+  });
+});

--- a/packages/cli/src/managers/terminal-key-reader.manager.ts
+++ b/packages/cli/src/managers/terminal-key-reader.manager.ts
@@ -1,0 +1,94 @@
+import {injectable} from "tsyringe";
+import {moduleScoped} from "@pristine-ts/common";
+import {CliModuleKeyname} from "../cli.module.keyname";
+import {TerminalKey} from "../interfaces/terminal-key.interface";
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+import {TerminalKeyDecoder} from "../utils/terminal-key-decoder";
+import {PromptCancelledError} from "../errors/prompt-cancelled.error";
+
+/**
+ * Owns the raw-mode keystroke reading the interactive prompts need (arrow-key `select`,
+ * masked `readSecret`) — the one place in the CLI that flips stdin into raw mode. Node's
+ * stock `readline` is line-buffered and echoes input, so it can't drive an arrow-key menu
+ * or suppress a password's characters; this reads keys one at a time instead.
+ *
+ * Two responsibilities are handled centrally so callers don't each reimplement them:
+ *   - **Cancellation:** `Ctrl+C` rejects the read with {@link PromptCancelledError}.
+ *   - **Terminal restore:** raw mode is entered on start and restored in every exit path,
+ *     so a thrown handler or a cancellation never leaves the terminal in raw mode.
+ *
+ * The `input`/`output` fields default to the process streams and exist as a seam so tests
+ * can drive synthetic keystrokes without a real TTY.
+ */
+@injectable()
+@moduleScoped(CliModuleKeyname)
+export class TerminalKeyReader {
+  input: NodeJS.ReadStream = process.stdin;
+  output: NodeJS.WriteStream = process.stdout;
+
+  /**
+   * Whether both stdin and stdout are interactive terminals. Raw-mode reading is only
+   * meaningful on a real TTY; callers fall back (or skip prompting) when this is false.
+   */
+  isInteractive(): boolean {
+    return Boolean(this.input.isTTY) && Boolean(this.output.isTTY);
+  }
+
+  /**
+   * Reads keystrokes in raw mode, handing each decoded {@link TerminalKey} to `onKey` until
+   * `onKey` ends the read by invoking its `resolve` callback with the result. Resolves to
+   * that value; rejects with {@link PromptCancelledError} on `Ctrl+C`. Raw mode is entered
+   * on start and restored to its prior state in every exit path.
+   */
+  read<T>(onKey: (key: TerminalKey, resolve: (value: T) => void) => void): Promise<T> {
+    const input = this.input;
+    const wasRaw = input.isRaw === true;
+
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = () => {
+        input.removeListener("data", onData);
+        if (input.isTTY && typeof input.setRawMode === "function") {
+          input.setRawMode(wasRaw);
+        }
+        input.pause();
+      };
+
+      const settle = (run: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        run();
+      };
+
+      const onData = (data: Buffer | string) => {
+        for (const key of TerminalKeyDecoder.decode(data.toString())) {
+          if (key.name === TerminalKeyName.CtrlC) {
+            settle(() => reject(new PromptCancelledError()));
+            return;
+          }
+
+          try {
+            onKey(key, (value: T) => settle(() => resolve(value)));
+          } catch (error) {
+            settle(() => reject(error as Error));
+            return;
+          }
+
+          if (settled) {
+            return;
+          }
+        }
+      };
+
+      if (input.isTTY && typeof input.setRawMode === "function") {
+        input.setRawMode(true);
+      }
+      input.resume();
+      input.on("data", onData);
+    });
+  }
+}

--- a/packages/cli/src/services/command-parameter-prompter.ts
+++ b/packages/cli/src/services/command-parameter-prompter.ts
@@ -12,6 +12,7 @@ import {CliOutput} from "../managers/cli-output.manager";
 import {CliDecoratorMetadataKeynameEnum} from "../enums/cli-decorator-metadata-keyname.enum";
 import {CommandParameterOptions} from "../options/command-parameter.options";
 import {CliErrorCode} from "../errors/cli-error-code.enum";
+import {BooleanAnswerParser} from "../utils/boolean-answer-parser";
 
 /**
  * Applies a command's `@commandParameter` metadata to its raw, parsed arguments before they
@@ -168,7 +169,7 @@ export class CommandParameterPrompter {
       }
 
       if (isBoolean) {
-        const parsed = this.parseBoolean(raw);
+        const parsed = BooleanAnswerParser.parse(raw);
         if (parsed === undefined) {
           this.cliOutput.writeLine("Please answer yes (y) or no (n).");
           continue;
@@ -269,22 +270,6 @@ export class CommandParameterPrompter {
       }
     }
 
-    return undefined;
-  }
-
-  /**
-   * Interprets a free-text answer as a boolean the way traditional CLIs do. Returns undefined
-   * for anything unrecognized so the caller can re-ask.
-   * @private
-   */
-  private parseBoolean(raw: string): boolean | undefined {
-    const normalized = raw.toLowerCase();
-    if (normalized === "y" || normalized === "yes" || normalized === "true" || normalized === "1") {
-      return true;
-    }
-    if (normalized === "n" || normalized === "no" || normalized === "false" || normalized === "0") {
-      return false;
-    }
     return undefined;
   }
 

--- a/packages/cli/src/utils/boolean-answer-parser.spec.ts
+++ b/packages/cli/src/utils/boolean-answer-parser.spec.ts
@@ -1,0 +1,24 @@
+import {BooleanAnswerParser} from "./boolean-answer-parser";
+
+describe("BooleanAnswerParser", () => {
+  it.each(["y", "yes", "YES", "Yes", "true", "TRUE", "1", "  y  "])(
+    "parses '%s' as true",
+    (input) => {
+      expect(BooleanAnswerParser.parse(input)).toBe(true);
+    },
+  );
+
+  it.each(["n", "no", "NO", "No", "false", "FALSE", "0", "  n  "])(
+    "parses '%s' as false",
+    (input) => {
+      expect(BooleanAnswerParser.parse(input)).toBe(false);
+    },
+  );
+
+  it.each(["maybe", "yep", "2", "", "   ", "ok"])(
+    "returns undefined for the unrecognized answer '%s'",
+    (input) => {
+      expect(BooleanAnswerParser.parse(input)).toBeUndefined();
+    },
+  );
+});

--- a/packages/cli/src/utils/boolean-answer-parser.ts
+++ b/packages/cli/src/utils/boolean-answer-parser.ts
@@ -1,0 +1,20 @@
+/**
+ * Interprets a free-text answer as a boolean the way traditional CLIs do — accepting
+ * `y`/`yes`/`true`/`1` and `n`/`no`/`false`/`0` (case-insensitive, surrounding whitespace
+ * ignored). Returns `undefined` for anything unrecognized so callers can re-ask.
+ *
+ * Shared by `CliPrompt.confirm` (yes/no prompts) and `CommandParameterPrompter` (typed
+ * boolean parameters) so both accept exactly the same set of answers.
+ */
+export class BooleanAnswerParser {
+  static parse(raw: string): boolean | undefined {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === "y" || normalized === "yes" || normalized === "true" || normalized === "1") {
+      return true;
+    }
+    if (normalized === "n" || normalized === "no" || normalized === "false" || normalized === "0") {
+      return false;
+    }
+    return undefined;
+  }
+}

--- a/packages/cli/src/utils/terminal-key-decoder.spec.ts
+++ b/packages/cli/src/utils/terminal-key-decoder.spec.ts
@@ -1,0 +1,46 @@
+import {TerminalKeyDecoder} from "./terminal-key-decoder";
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+
+describe("TerminalKeyDecoder", () => {
+  it("decodes a single printable character", () => {
+    expect(TerminalKeyDecoder.decode("a")).toEqual([{name: TerminalKeyName.Character, sequence: "a"}]);
+  });
+
+  it("splits a multi-character chunk (paste / fast typing) into one Character key each", () => {
+    expect(TerminalKeyDecoder.decode("abc")).toEqual([
+      {name: TerminalKeyName.Character, sequence: "a"},
+      {name: TerminalKeyName.Character, sequence: "b"},
+      {name: TerminalKeyName.Character, sequence: "c"},
+    ]);
+  });
+
+  it.each([["\r"], ["\n"]])("decodes Enter from %j", (sequence) => {
+    expect(TerminalKeyDecoder.decode(sequence)).toEqual([{name: TerminalKeyName.Enter, sequence}]);
+  });
+
+  it.each([["\x7f"], ["\b"]])("decodes Backspace from %j", (sequence) => {
+    expect(TerminalKeyDecoder.decode(sequence)[0].name).toBe(TerminalKeyName.Backspace);
+  });
+
+  it("decodes Ctrl+C", () => {
+    expect(TerminalKeyDecoder.decode("\x03")[0].name).toBe(TerminalKeyName.CtrlC);
+  });
+
+  it("decodes the up and down arrows", () => {
+    expect(TerminalKeyDecoder.decode("\x1b[A")[0].name).toBe(TerminalKeyName.Up);
+    expect(TerminalKeyDecoder.decode("\x1b[B")[0].name).toBe(TerminalKeyName.Down);
+  });
+
+  it("treats an unrecognized escape sequence as a single Other key", () => {
+    expect(TerminalKeyDecoder.decode("\x1b[C")).toEqual([{name: TerminalKeyName.Other, sequence: "\x1b[C"}]);
+  });
+
+  it("maps a stray control byte inside a printable run to Other and keeps the rest", () => {
+    const keys = TerminalKeyDecoder.decode("a\x01b");
+    expect(keys.map((key) => key.name)).toEqual([
+      TerminalKeyName.Character,
+      TerminalKeyName.Other,
+      TerminalKeyName.Character,
+    ]);
+  });
+});

--- a/packages/cli/src/utils/terminal-key-decoder.ts
+++ b/packages/cli/src/utils/terminal-key-decoder.ts
@@ -1,0 +1,69 @@
+import {TerminalKey} from "../interfaces/terminal-key.interface";
+import {TerminalKeyName} from "../enums/terminal-key-name.enum";
+
+/**
+ * Translates the raw bytes Node delivers from a raw-mode stdin into structured
+ * {@link TerminalKey}s. Pure and static so it can be unit-tested without a real TTY.
+ *
+ * A single `data` chunk can carry more than one keystroke (notably a paste, or fast
+ * typing), so this returns an array. Control and escape sequences are recognized as one
+ * key each; a run of printable characters is split into one `Character` key per character
+ * so callers (masked input, menus) can echo and handle them uniformly.
+ */
+export class TerminalKeyDecoder {
+  /**
+   * Decodes a raw stdin chunk into the keys it represents.
+   *
+   *   - A recognized control byte / escape sequence that spans the whole chunk → one key.
+   *   - An unrecognized escape sequence (starts with ESC) → a single `Other` key, rather
+   *     than splitting it into bogus printable characters.
+   *   - Anything else → one key per character, with non-printable control bytes mapped to
+   *     `Other` so they're ignored rather than echoed.
+   */
+  static decode(data: string): TerminalKey[] {
+    const whole = TerminalKeyDecoder.decodeControl(data);
+    if (whole !== undefined) {
+      return [whole];
+    }
+
+    if (data.charCodeAt(0) === 0x1b) {
+      return [{name: TerminalKeyName.Other, sequence: data}];
+    }
+
+    const keys: TerminalKey[] = [];
+    for (const character of data) {
+      const control = TerminalKeyDecoder.decodeControl(character);
+      if (control !== undefined) {
+        keys.push(control);
+      } else if (character.charCodeAt(0) < 0x20) {
+        keys.push({name: TerminalKeyName.Other, sequence: character});
+      } else {
+        keys.push({name: TerminalKeyName.Character, sequence: character});
+      }
+    }
+    return keys;
+  }
+
+  /**
+   * Maps a single recognized control byte or escape sequence to its key, or `undefined`
+   * when the input isn't one we handle.
+   * @private
+   */
+  private static decodeControl(sequence: string): TerminalKey | undefined {
+    switch (sequence) {
+      case "\x1b[A":
+        return {name: TerminalKeyName.Up, sequence};
+      case "\x1b[B":
+        return {name: TerminalKeyName.Down, sequence};
+      case "\r":
+      case "\n":
+        return {name: TerminalKeyName.Enter, sequence};
+      case "\x7f":
+      case "\b":
+        return {name: TerminalKeyName.Backspace, sequence};
+      case "\x03":
+        return {name: TerminalKeyName.CtrlC, sequence};
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
## What

Reimplements the four prompt types `@pristine-ts/cli` actually used — `input`, `confirm`, `select`, and masked password — directly on Node's `readline` + raw-mode stdin, and removes the `@inquirer/prompts` dependency (and its ~20 transitive packages, incl. `iconv-lite`/`chardet`/`tmp`).

This honours the standing guidance in `AGENTS.md` ("Do not introduce heavy UI libraries like `inquirer`… implement features using native ANSI codes and `readline`").

## How

- **`CliPrompt`** gains native `input`/`confirm`/`select` (arrow-key menu) and a real raw-mode masked `readSecret`, replacing the previous fake post-input clear.
- **`TerminalKeyReader`** is the single place that flips stdin into raw mode; it restores the terminal in every exit path.
- **`Ctrl+C`** rejects every prompt with `PromptCancelledError` (exit 130, `UserError`), so the reporter prints it cleanly. `BuildStalenessPrompt` catches it as before.
- **`TerminalKeyDecoder`** (pure) and **`BooleanAnswerParser`** (shared with `CommandParameterPrompter`) are extracted as tested utilities.
- `InitPrompt` / `BuildStalenessPrompt` now depend on `CliPrompt`; the pre-kernel wiring in `cli.ts` constructs it manually. `DynamicImporter` is unchanged (still used by config/plugin/module loaders).
- `@inquirer/prompts` removed from `package.json`; lockfiles regenerated.

## Verification

- `npm run build` (cli) green.
- `npx jest` → **15 suites / 126 tests pass** (new decoder/reader/parser/select/readSecret tests; existing `CommandParameterPrompter` suite unaffected).
- Zero `@inquirer` references remain in `src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)