### PR TITLE
Re-export module keynames from cli and networking barrels

### DIFF
--- a/packages/cli/src/cli.module.ts
+++ b/packages/cli/src/cli.module.ts
@@ -24,6 +24,7 @@ export * from "./options/options";
 export * from "./reporters/cli-error.reporter";
 export * from "./services/services";
 export * from "./types/types";
+export * from "./cli.module.keyname";
 
 // Re-export the `Cli` entrypoint so `bin.ts` (and any other downstream entry script) can
 // invoke `new (require('@pristine-ts/cli').Cli)().bootstrap()` to load the same physical

--- a/packages/networking/src/networking.module.ts
+++ b/packages/networking/src/networking.module.ts
@@ -25,6 +25,7 @@ export * from "./router";
 export * from "./responders/http-error.responder";
 
 export * from "./networking.configuration-keys";
+export * from "./networking.module.keyname";
 export const NetworkingModule: ModuleInterface = {
   keyname: NetworkingModuleKeyname,
   importModules: [


### PR DESCRIPTION
## What

`CliModuleKeyname` (`@pristine-ts/cli`) and `NetworkingModuleKeyname` (`@pristine-ts/networking`) were imported into their module barrels but never re-exported, so downstream consumers could not import them from the package entry points.

## Change

Added the missing `export *` line to each barrel, matching the convention already used by `core`, `common`, `logging`, and `configuration` (the module keyname re-exported as the last `export *`):

- `packages/cli/src/cli.module.ts` → `export * from "./cli.module.keyname";`
- `packages/networking/src/networking.module.ts` → `export * from "./networking.module.keyname";`

Purely additive re-exports — no behavior change. Networking typechecks clean; the CLI package's only `tsc` errors are pre-existing (an unrelated `plain` option on the error types) and are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)