### PR TITLE
fix(cli): warn on silent AppModule fallback + correct AppModule-discovery docs

### DIFF
--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -782,32 +782,40 @@ provenance markers. Use this when discovery is doing something unexpected.
 
 ## How `pristine` finds your AppModule
 
-When the CLI starts, it walks this cascade. The first match wins.
+There is exactly **one** supported way to declare your AppModule: the `cli.appModule` block in
+`pristine.config.{ts,js}`. The loader does **not** scan `package.json`, does **not** scan `dist/`
+by convention, and does **not** cache a previous selection — those earlier mechanisms were
+removed. The flow is two-tier:
 
 ```
-1. pristine.config.ts → appModule.path
-        ↓ (not set?)
-2. package.json → pristine.appModule.path
-        ↓ (deprecated alias: pristine.appModule.cjsPath, prints warning)
-        ↓ (not set?)
-3. .pristine/last-app-module        ← cached selection from a previous TTY prompt
-        ↓ (not set?)
-4. Convention scan: dist/, dist/lib/cjs/, dist/lib/esm/, build/, .
-   for *.module.{js,mjs,cjs}
-        ├── named app.module.* → score 0
-        └── exports an AppModule symbol → score 10
-   ── one match? → use it
-   ── multiple equally-ranked + TTY? → prompt
-   ── multiple equally-ranked + no TTY? → exit with actionable error
-        ↓ (no candidates?)
-5. Legacy node_modules/@pristine-ts/* scan (synthetic AppModule)
-        ↓ (still nothing?)
-6. Built-in CliModule fallback (so p:help etc. always work)
+1. Read pristine.config.{ts,js} (walking up from cwd).
+        │
+        ├─ cli.appModule.sourcePath + outputPath both set?
+        │     → manifest gate (is the build fresh? prompt on a TTY, fail on CI),
+        │       then import outputPath and read `export` (default: "AppModule").
+        │
+        └─ otherwise → the CliModule-only fallback below.
+
+2. CliModule-only fallback — used when there is no config file, no cli.appModule block, or the
+   configured outputPath fails to import. Scrapes node_modules/@pristine-ts/* for the modules
+   they contribute (so built-ins like p:help / p:list still work) and adds CliModule.
+   YOUR AppModule and its commands are NOT loaded in this mode.
 ```
 
-If a configured AppModule path can't be loaded (file missing, import error), the CLI
-warns to stderr and falls back to the CliModule fallback. Built-in commands like
-`pristine p:config:print` still work so you can debug.
+The fallback is the only escape hatch — it keeps `pristine init` / `pristine help` runnable on a
+broken or fresh project. It is **not** a discovery tier. When the loader falls back even though
+you expected your AppModule to load, it warns to stderr so the failure isn't invisible (otherwise
+a command like `cicd:run` simply "doesn't exist" with no explanation):
+
+- **Configured `outputPath` can't be imported** (missing file, import error) →
+  `[pristine] Failed to load AppModule from '…'`.
+- **`pristine.config.ts` present but missing `cli.appModule`** → a "no 'cli.appModule'" warning.
+- **Leftover `package.json` `pristine.appModule.{path,cjsPath}`** (the discovery field removed in
+  2.x, now ignored) → a "legacy field … is ignored" warning. Move it into `pristine.config.ts`
+  or run `pristine init`.
+
+A genuinely empty project (no config file, no legacy field) stays silent so a first-run
+`pristine init` isn't noisy.
 
 ### Module formats
 

--- a/packages/cli/src/bootstrap/app-module-loader.ts
+++ b/packages/cli/src/bootstrap/app-module-loader.ts
@@ -123,9 +123,14 @@ export class AppModuleLoader {
         appModule = await this.buildFallbackAppModule(projectRoot);
       }
     } else {
-      // Stage 4 (no `cli.appModule` block, or no config file at all): substitute the
-      // CliModule-only AppModule so the bin can still bootstrap the user's project.
-      // First-run case (`pristine init` from a fresh project) lands here.
+      // Stage 4 (no `cli.appModule` resolved): substitute the CliModule-only AppModule so the
+      // bin can still bootstrap. A genuinely fresh project (no config file, no legacy field)
+      // stays quiet so `pristine init` / `pristine help` aren't noisy. But when the user clearly
+      // expected their AppModule to load — a config file that forgot `cli.appModule`, or a
+      // leftover `package.json` `pristine.appModule` field from before 2.x — warn loudly so the
+      // failure isn't invisible. Without this, a user command like `cicd:run` simply "doesn't
+      // exist" with no explanation. (This is the "old paths fail loudly" the migration docs promise.)
+      this.warnNoAppModuleResolved(projectRoot, resolvedConfig.configFilePath);
       appModule = await this.buildFallbackAppModule(projectRoot);
     }
 
@@ -147,6 +152,70 @@ export class AppModuleLoader {
     }
 
     return new LoadedAppModule(appModule, plugins);
+  }
+
+  /**
+   * Emits an actionable stderr warning when the loader is about to fall back to a CliModule-only
+   * AppModule because no `cli.appModule` resolved — but only in the cases where the user most
+   * likely expected their AppModule to load. A pristine-free project (no config file AND no
+   * legacy field) stays silent so `pristine init` on a fresh checkout isn't noisy.
+   *
+   * Two cases warn:
+   *   1. A legacy `package.json` `pristine.appModule.{path,cjsPath}` field is still present. That
+   *      discovery mechanism was removed in 2.x; the field is now silently ignored, which is
+   *      exactly the "silent half-migration" the docs promise not to allow — so we flag it.
+   *   2. A config file exists but declares no `cli.appModule`.
+   * @private
+   */
+  private warnNoAppModuleResolved(projectRoot: string, configFilePath: string | undefined): void {
+    const legacyField = this.detectLegacyPackageJsonAppModule(projectRoot);
+    if (legacyField !== undefined) {
+      process.stderr.write(
+        `[pristine] Found a legacy '${legacyField}' field in package.json. That AppModule-discovery ` +
+        `mechanism was removed in 2.x — Pristine no longer reads package.json, so the field is ignored.\n` +
+        `[pristine] Your AppModule is NOT loaded and its commands are missing (only built-in commands run). ` +
+        `Move it to a pristine.config.ts (cli.appModule.sourcePath + outputPath) — run \`pristine init\`.\n`,
+      );
+      return;
+    }
+    if (configFilePath !== undefined) {
+      process.stderr.write(
+        `[pristine] '${path.basename(configFilePath)}' has no 'cli.appModule' — your AppModule is NOT ` +
+        `loaded, so only built-in commands are available.\n` +
+        `[pristine] Add cli.appModule.sourcePath + outputPath (or run \`pristine init\`) to load it.\n`,
+      );
+    }
+    // No config file and no legacy field → genuine fresh / built-in-only use; stay silent.
+  }
+
+  /**
+   * Best-effort read of the project's package.json to detect a legacy AppModule-discovery field.
+   * Returns the dotted path of the offending field (`pristine.appModule.cjsPath` /
+   * `pristine.appModule.path`, or `pristine.appModule` when neither sub-key is a string) when
+   * present, else undefined. A missing or unparseable package.json yields undefined.
+   * @private
+   */
+  private detectLegacyPackageJsonAppModule(projectRoot: string): string | undefined {
+    try {
+      const packageJsonPath = path.resolve(projectRoot, "package.json");
+      if (fs.existsSync(packageJsonPath) === false) {
+        return undefined;
+      }
+      const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      const appModule = parsed?.pristine?.appModule;
+      if (appModule === undefined || appModule === null) {
+        return undefined;
+      }
+      if (typeof appModule.cjsPath === "string") {
+        return "pristine.appModule.cjsPath";
+      }
+      if (typeof appModule.path === "string") {
+        return "pristine.appModule.path";
+      }
+      return "pristine.appModule";
+    } catch {
+      return undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When the CLI's `AppModuleLoader` can't resolve `cli.appModule`, it substitutes a `CliModule`-only AppModule so built-in commands keep working. But it does this **silently** in the most common failure cases — so a consumer's commands just disappear with no explanation. This is exactly how `@magieno/cicd`'s `cicd:run` vanished after a 2.x upgrade: no `pristine.config.ts` → silent fallback → "command never registers."

The migration docs promise the old `package.json` paths "fail loudly so you don't end up with silent half-migrations" — but the shipped loader doesn't read `package.json` at all, so a leftover field is silently ignored.

## Changes

**`packages/cli/src/bootstrap/app-module-loader.ts`** — the no-`appModule` fallback now warns to stderr when the user most likely expected their AppModule to load:

- A leftover `package.json` `pristine.appModule.{path,cjsPath}` field (removed in 2.x, now ignored) → a clear "legacy field is ignored, move it to pristine.config.ts" warning. This delivers the "old paths fail loudly" the docs promise.
- A `pristine.config.ts` present but missing `cli.appModule` → a "no 'cli.appModule'" warning.
- A genuinely empty project (no config, no legacy field) stays **silent**, so a first-run `pristine init` / `pristine help` isn't noisy.

**`packages/cli/readme.md`** — the "How `pristine` finds your AppModule" section described a fictional 6-tier cascade (package.json discovery, `.pristine/last-app-module` cache, convention scan) that the shipped loader does **not** do (its own JSDoc says "no convention scan, no package.json discovery, no cached prior selection"). Rewrote it to the actual two-tier flow — `pristine.config.ts` `cli.appModule` (`sourcePath`+`outputPath`, manifest-gated) → `CliModule`-only fallback — and documented the new warnings.

## Test plan

- [x] `app-module-loader.ts` typechecks clean (`tsc --noEmit -p packages/cli/tsconfig.json`; the only errors are pre-existing and in unrelated files).
- [ ] Manual: a project with a leftover `package.json` `pristine.appModule.cjsPath` and no config now prints the legacy-field warning instead of silently dropping its commands.
- [ ] Manual: a `pristine.config.ts` with no `cli.appModule` prints the "no 'cli.appModule'" warning.
- [ ] Manual: a bare project (no config, no legacy field) stays silent.

## Context

Companion consumer-side fix: magieno/magieno#206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw98BpUo8sWktameAJBN3g
