### PR TITLE
build(ts6): migrate toolchain to TypeScript 6.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,14 +24,17 @@ module.exports = {
             {'ts-ignore': 'allow-with-description'},
         ],
         "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/ban-types": [
-            'error',
-            {
-                "types": {
-                    "Function": false,
-                }
-            }
-        ]
+        // `ban-types` was removed in @typescript-eslint v8 and split into
+        // dedicated rules. The only customization here was allowing the
+        // `Function` type, so we simply disable its replacement rule.
+        "@typescript-eslint/no-unsafe-function-type": "off",
+        // Empty interfaces are used intentionally as declaration-merging
+        // extension points (e.g. PristineConfigurationValueMap), so allow
+        // them while still flagging the empty `{}` object type.
+        "@typescript-eslint/no-empty-object-type": ["error", {"allowInterfaces": "always"}],
+        // The codebase relies on the `cond && sideEffect()` short-circuit idiom,
+        // which v8's recommended config flags via no-unused-expressions.
+        "@typescript-eslint/no-unused-expressions": ["error", {"allowShortCircuit": true, "allowTernary": true}]
     }
 }
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.21"
+  "version": "3.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,14 +48,14 @@
       "devDependencies": {
         "@types/jest": "^29.5.7",
         "@types/node": "^18.18.8",
-        "@typescript-eslint/eslint-plugin": "^6.9.1",
-        "@typescript-eslint/parser": "^6.9.1",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.52.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
         "lerna": "^9.0.3",
-        "ts-jest": "^29.1.1",
-        "typescript": "^5.2.2"
+        "ts-jest": "^29.4.11",
+        "typescript": "^6.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3461,29 +3461,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/arborist/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/arborist/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@npmcli/arborist/node_modules/lru-cache": {
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
@@ -3492,22 +3469,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/arborist/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@npmcli/arborist/node_modules/npm-bundled": {
@@ -3737,29 +3698,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/map-workspaces/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@npmcli/map-workspaces/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -3770,22 +3708,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3860,29 +3782,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/package-json/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@npmcli/package-json/node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -3903,22 +3802,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4077,45 +3960,6 @@
       },
       "peerDependencies": {
         "nx": ">= 21 <= 23 || ^22.0.0-0"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
@@ -5337,45 +5181,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@tufjs/models/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -5553,13 +5358,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -5719,13 +5517,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -5801,124 +5592,159 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5926,76 +5752,134 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -6248,16 +6132,6 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/arrify": {
       "version": "1.0.1",
@@ -6925,29 +6799,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/cacache/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/cacache/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -6974,22 +6825,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cacache/node_modules/p-map": {
@@ -7897,19 +7732,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -8722,36 +8544,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9505,27 +9297,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -10090,45 +9861,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/immediate": {
@@ -11841,6 +11573,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/lerna/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/lerna/node_modules/write-file-atomic": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -12554,16 +12300,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -12653,19 +12389,42 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -13525,22 +13284,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/nx/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/nx/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -14204,16 +13947,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -16242,16 +15975,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -16484,9 +16217,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
   "devDependencies": {
     "@types/jest": "^29.5.7",
     "@types/node": "^18.18.8",
-    "@typescript-eslint/eslint-plugin": "^6.9.1",
-    "@typescript-eslint/parser": "^6.9.1",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.52.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
     "lerna": "^9.0.3",
-    "ts-jest": "^29.1.1",
-    "typescript": "^5.2.2"
+    "ts-jest": "^29.4.11",
+    "typescript": "^6.0.0"
   },
   "dependencies": {
     "@pristine-ts/auth0": "file:packages/auth0",

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/auth0",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/auth0.module.js",
   "main": "dist/lib/cjs/auth0.module.js",

--- a/packages/auth0/tsconfig.json
+++ b/packages/auth0/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/aws-api-gateway/package.json
+++ b/packages/aws-api-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/aws-api-gateway",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/aws-api-gateway.module.js",
   "main": "dist/lib/cjs/aws-api-gateway.module.js",

--- a/packages/aws-api-gateway/tsconfig.json
+++ b/packages/aws-api-gateway/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/aws-cognito/package.json
+++ b/packages/aws-cognito/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/aws-cognito",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/aws-cognito.module.js",
   "main": "dist/lib/cjs/aws-cognito.module.js",

--- a/packages/aws-cognito/tsconfig.json
+++ b/packages/aws-cognito/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/aws-scheduling/package.json
+++ b/packages/aws-scheduling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/aws-scheduling",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/aws-scheduling.module.js",
   "main": "dist/lib/cjs/aws-scheduling.module.js",

--- a/packages/aws-scheduling/tsconfig.json
+++ b/packages/aws-scheduling/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/aws-xray/package.json
+++ b/packages/aws-xray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/aws-xray",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/aws-xray.module.js",
   "main": "dist/lib/cjs/aws-xray.module.js",

--- a/packages/aws-xray/tsconfig.json
+++ b/packages/aws-xray/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/aws",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/aws.module.js",
   "main": "dist/lib/cjs/aws.module.js",

--- a/packages/aws/tsconfig.json
+++ b/packages/aws/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "strict": false
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/cli",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/cli.module.js",
   "main": "dist/lib/cjs/cli.module.js",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 // This file is intentionally CJS `require()` rather than ESM `import`. It runs as the bin
 // entry compiled to dist/lib/cjs/bin.js, where (a) the load order matters (reflect-metadata
 // MUST initialize before any decorated class is touched) and (b) static `import` cannot be

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "lib": ["es2020", "es2022.error"]
   },

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/cloudflare",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/cloudflare.module.js",
   "main": "dist/lib/cjs/cloudflare.module.js",

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "types": [
       "jest"
     ],

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/common",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/common.module.js",
   "main": "dist/lib/cjs/common.module.js",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "lib": ["es2020", "es2022.error"]
   },

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/configuration",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/configuration.module.js",
   "main": "dist/lib/cjs/configuration.module.js",

--- a/packages/configuration/tsconfig.json
+++ b/packages/configuration/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/core",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/core.module.js",
   "main": "dist/lib/cjs/core.module.js",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/data-mapping-common/package.json
+++ b/packages/data-mapping-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/data-mapping-common",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/data-mapping-common.js",
   "main": "dist/lib/cjs/data-mapping-common.js",

--- a/packages/data-mapping-common/tsconfig.json
+++ b/packages/data-mapping-common/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/data-mapping/package.json
+++ b/packages/data-mapping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/data-mapping",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/data-mapping.module.js",
   "main": "dist/lib/cjs/data-mapping.module.js",

--- a/packages/data-mapping/tsconfig.json
+++ b/packages/data-mapping/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,11 +29,11 @@
     "typescript": ">=5.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^7.0.0"
+    "@typescript-eslint/utils": "^8.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/parser": "^7.0.0",
-    "@typescript-eslint/rule-tester": "^7.0.0"
+    "@typescript-eslint/parser": "^8.0.0",
+    "@typescript-eslint/rule-tester": "^8.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pristine-ts/eslint-plugin",
   "private": true,
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "ESLint rules for projects using the Pristine framework. Currently ships one rule: inject-config-type-match.",
   "module": "dist/lib/esm/index.js",
   "main": "dist/lib/cjs/index.js",

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "bundler",
     "module": "ES2020",
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/express",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/express.module.js",
   "main": "dist/lib/cjs/express.module.js",

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/file",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/file.module.js",
   "main": "dist/lib/cjs/file.module.js",

--- a/packages/file/tsconfig.json
+++ b/packages/file/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/gcp-functions/package.json
+++ b/packages/gcp-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/gcp-functions",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/gcp-functions.module.js",
   "main": "dist/lib/cjs/gcp-functions.module.js",

--- a/packages/gcp-functions/tsconfig.json
+++ b/packages/gcp-functions/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "strict": false
   },

--- a/packages/gcp-identity-platform/package.json
+++ b/packages/gcp-identity-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/gcp-identity-platform",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/gcp-identity-platform.module.js",
   "main": "dist/lib/cjs/gcp-identity-platform.module.js",

--- a/packages/gcp-identity-platform/tsconfig.json
+++ b/packages/gcp-identity-platform/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "strict": false
   },

--- a/packages/gcp-scheduling/package.json
+++ b/packages/gcp-scheduling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/gcp-scheduling",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/gcp-scheduling.module.js",
   "main": "dist/lib/cjs/gcp-scheduling.module.js",

--- a/packages/gcp-scheduling/tsconfig.json
+++ b/packages/gcp-scheduling/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "strict": false
   },

--- a/packages/gcp-trace/package.json
+++ b/packages/gcp-trace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/gcp-trace",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/gcp-trace.module.js",
   "main": "dist/lib/cjs/gcp-trace.module.js",

--- a/packages/gcp-trace/tsconfig.json
+++ b/packages/gcp-trace/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "strict": false
   },

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/gcp",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/gcp.module.js",
   "main": "dist/lib/cjs/gcp.module.js",

--- a/packages/gcp/tsconfig.json
+++ b/packages/gcp/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "strict": false
   },

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/http",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/http.module.js",
   "main": "dist/lib/cjs/http.module.js",

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/jwt",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/jwt.module.js",
   "main": "dist/lib/cjs/jwt.module.js",

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/logging",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/logging.module.js",
   "main": "dist/lib/cjs/logging.module.js",

--- a/packages/logging/tsconfig.json
+++ b/packages/logging/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/mysql-cli/package.json
+++ b/packages/mysql-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/mysql-cli",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "Pristine CLI commands and TypeScript-defined SQL migrations for @pristine-ts/mysql.",
   "module": "dist/lib/esm/mysql-cli.module.js",
   "main": "dist/lib/cjs/mysql-cli.module.js",

--- a/packages/mysql-cli/tsconfig.json
+++ b/packages/mysql-cli/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/mysql-common/package.json
+++ b/packages/mysql-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/mysql-common",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/mysql-common.js",
   "main": "dist/lib/cjs/mysql-common.js",

--- a/packages/mysql-common/tsconfig.json
+++ b/packages/mysql-common/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/mysql",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/mysql.module.js",
   "main": "dist/lib/cjs/mysql.module.js",

--- a/packages/mysql/tsconfig.json
+++ b/packages/mysql/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/networking/package.json
+++ b/packages/networking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/networking",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/networking.module.js",
   "main": "dist/lib/cjs/networking.module.js",

--- a/packages/networking/tsconfig.json
+++ b/packages/networking/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm",
     "lib": ["es2020", "es2022.error"]
   },

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/observability",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/observability.module.js",
   "main": "dist/lib/cjs/observability.module.js",

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/opensearch/package.json
+++ b/packages/opensearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/opensearch",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/open-search.module.js",
   "main": "dist/lib/cjs/open-search.module.js",

--- a/packages/opensearch/tsconfig.json
+++ b/packages/opensearch/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/redis",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/redis.module.js",
   "main": "dist/lib/cjs/redis.module.js",

--- a/packages/redis/tsconfig.json
+++ b/packages/redis/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/scheduling",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/scheduling.module.js",
   "main": "dist/lib/cjs/scheduling.module.js",

--- a/packages/scheduling/tsconfig.json
+++ b/packages/scheduling/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/security",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/security.module.js",
   "main": "dist/lib/cjs/security.module.js",

--- a/packages/security/tsconfig.json
+++ b/packages/security/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/sentry",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/sentry.module.js",
   "main": "dist/lib/cjs/sentry.module.js",

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/stripe",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/stripe.module.js",
   "main": "dist/lib/cjs/stripe.module.js",

--- a/packages/stripe/tsconfig.json
+++ b/packages/stripe/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/telemetry",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/telemetry.module.js",
   "main": "dist/lib/cjs/telemetry.module.js",

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pristine-ts/validation",
-  "version": "2.0.21",
+  "version": "3.0.0",
   "description": "",
   "module": "dist/lib/esm/validation.module.js",
   "main": "dist/lib/cjs/validation.module.js",

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": [

--- a/tests/cli/tsconfig.json
+++ b/tests/cli/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "rootDir": "src",
     "outDir": "dist/lib/esm"
   },
   "exclude": ["./**/*.spec.ts", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,11 @@
     "typeRoots": [
       "node_modules/@types"
     ],
+    "types": [
+      "node",
+      "jest"
+    ],
+    "ignoreDeprecations": "6.0",
     "skipLibCheck": true,
     "allowJs": true,
     "incremental": true


### PR DESCRIPTION
## Summary

Migrates the monorepo to **TypeScript 6.0** (the last JS-based release, current `latest` 6.0.3), along with the toolchain bumps it forces. The headline: **no application source needed to change** — the decorator + `reflect-metadata` DI core is fully compatible with 6.0's `experimentalDecorators`/`emitDecoratorMetadata`. Every change is config/dependency hygiene for 6.0's new defaults and the `@typescript-eslint` v8 jump.

Landed in two reviewable commits.

### Commit 1 — TS 6.0 bump + tsconfig adaptation
- Deps: `typescript` `^5.2.2` → `^6.0.0`; `@typescript-eslint/*` `^6`/`^7` → `^8` (v6/v7 don't support TS 6); `ts-jest` `^29.1.1` → `^29.4.11`.
- Root `tsconfig.json`: pin `types: ["node","jest"]` (6.0 changes the `types` default to `[]`) and add `ignoreDeprecations: "6.0"` (silences the `moduleResolution: node`/node10 deprecation that is now an error).
- Add `rootDir: "src"` to all 37 package tsconfigs — 6.0 changes the default `rootDir`, which would otherwise nest emitted output under an extra `src/` level (TS5011). It lives per-package because `rootDir` is a path option resolved relative to the file that declares it.

### Commit 2 — test harnesses + eslint v8 surface
- `tests/cli`: same `rootDir` fix (it has a real `tsc` build). The e2e/perf harnesses run only through ts-jest and needed none.
- `.eslintrc.js`: v8 removed `ban-types` (split into dedicated rules) and adds stricter recommended rules. Re-expressed the project's prior intent — disable `no-unsafe-function-type` (`Function` was explicitly allowed), allow empty interfaces in `no-empty-object-type` (used as declaration-merging extension points like `PristineConfigurationValueMap`), and permit the `cond && sideEffect()` idiom via `no-unused-expressions` `{ allowShortCircuit, allowTernary }`.
- `bin.ts`: update the inline disable from the removed `no-var-requires` to its v8 replacement `no-require-imports`.

## Verification (all green under TS 6.0.3)
- **Build:** `lerna run build` → 37/37 packages, **0 TS errors**.
- **Test:** `lerna run test` → 37/37 packages pass.
- **Harnesses:** cli build + jest (9), e2e (115 tests / 33 suites), perf (3) all pass.
- **Lint:** `eslint packages/**/src` clean under `@typescript-eslint` 8.62.

## Follow-up (intentionally out of scope)
`ignoreDeprecations: "6.0"` is a temporary shim that won't exist in TS 7.0. Before then, `moduleResolution: "node"` should move to `bundler`/`nodenext`. Left for a separate, focused pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7FkAZTRFg4RVDs5bMtCF)_