### PR TITLE
feat(common): make @pristine-ts/common browser-safe

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,6 +5,10 @@
   "module": "dist/lib/esm/common.module.js",
   "main": "dist/lib/cjs/common.module.js",
   "types": "dist/types/common.module.d.ts",
+  "browser": {
+    "./dist/lib/esm/managers/event-context.als.js": "./dist/lib/esm/managers/event-context.als.browser.js",
+    "./dist/lib/cjs/managers/event-context.als.js": "./dist/lib/cjs/managers/event-context.als.browser.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
     "prepublish": "npm run build",

--- a/packages/common/src/managers/event-context.als.browser.spec.ts
+++ b/packages/common/src/managers/event-context.als.browser.spec.ts
@@ -1,0 +1,40 @@
+import {eventContextStorage} from "./event-context.als.browser";
+import {EventContext} from "../contexts/event-context";
+
+const makeContext = (eventId: string): EventContext => ({eventId} as EventContext);
+
+describe("Browser EventContextStorage shim", () => {
+  it("exposes the active store synchronously inside run()", () => {
+    const ctx = makeContext("a");
+    const seen = eventContextStorage.run(ctx, () => eventContextStorage.getStore());
+    expect(seen).toBe(ctx);
+  });
+
+  it("has no active store outside of run()", () => {
+    expect(eventContextStorage.getStore()).toBeUndefined();
+  });
+
+  it("restores the previous store after run() returns", () => {
+    const outer = makeContext("outer");
+    eventContextStorage.run(outer, () => {
+      const inner = makeContext("inner");
+      eventContextStorage.run(inner, () => {
+        expect(eventContextStorage.getStore()).toBe(inner);
+      });
+      // Nested run() restored the outer context.
+      expect(eventContextStorage.getStore()).toBe(outer);
+    });
+    expect(eventContextStorage.getStore()).toBeUndefined();
+  });
+
+  it("restores the previous store even when the callback throws", () => {
+    expect(() => eventContextStorage.run(makeContext("boom"), () => {
+      throw new Error("boom");
+    })).toThrow("boom");
+    expect(eventContextStorage.getStore()).toBeUndefined();
+  });
+
+  it("returns the callback's return value", () => {
+    expect(eventContextStorage.run(makeContext("a"), () => 42)).toBe(42);
+  });
+});

--- a/packages/common/src/managers/event-context.als.browser.ts
+++ b/packages/common/src/managers/event-context.als.browser.ts
@@ -1,0 +1,30 @@
+import {EventContext} from "../contexts/event-context";
+import type {EventContextStorage} from "./event-context.als";
+
+/**
+ * Browser substitute for the Node `AsyncLocalStorage`-backed {@link EventContextStorage}.
+ * Browsers have no `async_hooks`, so this keeps the active `EventContext` in a single
+ * synchronous slot: it correctly scopes — and restores — the context for the synchronous
+ * portion of `run()` (including nested `run()` calls), but, unlike Node's
+ * `AsyncLocalStorage`, it cannot propagate across `await` boundaries, which no browser API
+ * supports.
+ */
+class SynchronousEventContextStorage implements EventContextStorage {
+  private store: EventContext | undefined;
+
+  run<T>(store: EventContext, callback: () => T): T {
+    const previous = this.store;
+    this.store = store;
+    try {
+      return callback();
+    } finally {
+      this.store = previous;
+    }
+  }
+
+  getStore(): EventContext | undefined {
+    return this.store;
+  }
+}
+
+export const eventContextStorage: EventContextStorage = new SynchronousEventContextStorage();

--- a/packages/common/src/managers/event-context.als.ts
+++ b/packages/common/src/managers/event-context.als.ts
@@ -1,0 +1,22 @@
+import {AsyncLocalStorage} from "async_hooks";
+import {EventContext} from "../contexts/event-context";
+
+/**
+ * The slice of `AsyncLocalStorage` that {@link EventContextManager} relies on. Pulling it
+ * behind this interface lets the storage backend be swapped per runtime: the Node build uses
+ * the real `AsyncLocalStorage` (below), while a browser build substitutes
+ * `event-context.als.browser.ts` (via the package's `browser` field), since `async_hooks`
+ * is Node-only and would otherwise break browser bundlers.
+ */
+export interface EventContextStorage {
+  run<T>(store: EventContext, callback: () => T): T;
+  getStore(): EventContext | undefined;
+}
+
+/**
+ * Process-wide storage backing the active `EventContext`. A single instance is essential —
+ * multiple `AsyncLocalStorage` instances would each track their own propagation chain and
+ * contexts wouldn't be visible across them. On Node this propagates the context across
+ * `await` boundaries, `Promise.all`, `setImmediate`, and the rest of the async machinery.
+ */
+export const eventContextStorage: EventContextStorage = new AsyncLocalStorage<EventContext>();

--- a/packages/common/src/managers/event-context.manager.ts
+++ b/packages/common/src/managers/event-context.manager.ts
@@ -1,7 +1,7 @@
-import {AsyncLocalStorage} from "async_hooks";
 import {DependencyContainer, injectable} from "tsyringe";
 import {EventContext} from "../contexts/event-context";
 import {TracingManagerInterface} from "../interfaces/tracing-manager.interface";
+import {eventContextStorage} from "./event-context.als";
 
 /**
  * Owns the `AsyncLocalStorage` instance that propagates the active `EventContext`
@@ -18,17 +18,14 @@ import {TracingManagerInterface} from "../interfaces/tracing-manager.interface";
  *     Captures the current context and returns a wrapped function that restores it
  *     on call.
  *
- * Why static state inside an `@injectable()` class: the `AsyncLocalStorage` instance
- * itself must be a single process-wide singleton — multiple instances would each track
- * their own propagation chain and contexts wouldn't be visible across them. Making the
- * ALS `private static readonly` while keeping the class `@injectable()` lets DI consumers
- * resolve it normally (and substitute fakes in tests) while the underlying state stays
- * shared and consistent.
+ * The backing storage lives in `./event-context.als` (a single process-wide
+ * `AsyncLocalStorage`) rather than being constructed here, so a browser build can swap it
+ * for a synchronous shim — `async_hooks` is Node-only. Keeping the storage shared while the
+ * class stays `@injectable()` lets DI consumers resolve the manager normally (and substitute
+ * fakes in tests) while the underlying state stays shared and consistent.
  */
 @injectable()
 export class EventContextManager {
-  private static readonly als = new AsyncLocalStorage<EventContext>();
-
   /**
    * Installs `ctx` as the active `EventContext` for the duration of `fn` (and every
    * async chain reachable from it). Returns whatever `fn` returns. Used by Pristine's
@@ -37,13 +34,13 @@ export class EventContextManager {
   run<T>(ctx: EventContext, fn: () => T): T;
   run<T>(ctx: EventContext, fn: () => Promise<T>): Promise<T>;
   run<T>(ctx: EventContext, fn: () => T | Promise<T>): T | Promise<T> {
-    return EventContextManager.als.run(ctx, fn);
+    return eventContextStorage.run(ctx, fn);
   }
 
   /** Returns the active `EventContext`, or `undefined` if no context is installed
    *  (i.e. we're outside any `run()` call). */
   current(): EventContext | undefined {
-    return EventContextManager.als.getStore();
+    return eventContextStorage.getStore();
   }
 
   /** Convenience: the `eventId` of the active context, or `undefined`. */
@@ -78,17 +75,16 @@ export class EventContextManager {
   bind<F extends (...args: any[]) => any>(fn: F): F {
     const ctx = this.current();
     if (ctx === undefined) return fn;
-    const als = EventContextManager.als;
-    return ((...args: any[]) => als.run(ctx, () => fn(...args))) as F;
+    return ((...args: any[]) => eventContextStorage.run(ctx, () => fn(...args))) as F;
   }
 
   // ── Static convenience mirrors. ────────────────────────────────────────────────
   // For callers that don't want DI noise (e.g. utility code, decorators, helpers
   // that don't have a constructor to inject through). All forwarding to the same
-  // shared ALS instance.
+  // shared storage instance.
 
   static current(): EventContext | undefined {
-    return EventContextManager.als.getStore();
+    return eventContextStorage.getStore();
   }
 
   static eventId(): string | undefined {
@@ -110,7 +106,6 @@ export class EventContextManager {
   static bind<F extends (...args: any[]) => any>(fn: F): F {
     const ctx = EventContextManager.current();
     if (ctx === undefined) return fn;
-    const als = EventContextManager.als;
-    return ((...args: any[]) => als.run(ctx, () => fn(...args))) as F;
+    return ((...args: any[]) => eventContextStorage.run(ctx, () => fn(...args))) as F;
   }
 }

--- a/packages/common/src/models/span.model.ts
+++ b/packages/common/src/models/span.model.ts
@@ -1,4 +1,4 @@
-import {randomUUID} from "crypto";
+import {UuidGenerator} from "../utils/uuid.util";
 import {SpanLifecycleOwnerInterface} from "./span-lifecycle-owner.interface";
 import {SpanMarker} from "./span-marker.model";
 import {Trace} from "./trace.model";
@@ -71,7 +71,7 @@ export class Span {
    * @param context The context to associate with the span.
    */
   public constructor(public keyname: string, id?: string, context?: { [key: string]: string }) {
-    this.id = id ?? randomUUID();
+    this.id = id ?? UuidGenerator.generate();
     this.context = context ?? {};
   }
 

--- a/packages/common/src/models/trace.model.ts
+++ b/packages/common/src/models/trace.model.ts
@@ -1,4 +1,4 @@
-import {randomUUID} from "crypto";
+import {UuidGenerator} from "../utils/uuid.util";
 import {Span} from "./span.model";
 
 /**
@@ -49,7 +49,7 @@ export class Trace {
    * @param context The context associated with the trace.
    */
   public constructor(id?: string, context?: { [key: string]: string }) {
-    this.id = id ?? randomUUID();
+    this.id = id ?? UuidGenerator.generate();
     this.context = context ?? {};
   }
 

--- a/packages/common/src/utils/utils.ts
+++ b/packages/common/src/utils/utils.ts
@@ -2,3 +2,4 @@ export * from "./date.util";
 export * from "./enum.util";
 export * from "./metadata.util";
 export * from "./object.util";
+export * from "./uuid.util";

--- a/packages/common/src/utils/uuid.util.spec.ts
+++ b/packages/common/src/utils/uuid.util.spec.ts
@@ -1,0 +1,47 @@
+import {UuidGenerator} from "./uuid.util";
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("UuidGenerator", () => {
+  const originalCrypto = (globalThis as { crypto?: unknown }).crypto;
+
+  const setCrypto = (value: unknown) => {
+    Object.defineProperty(globalThis, "crypto", {value, configurable: true, writable: true});
+  };
+
+  afterEach(() => {
+    setCrypto(originalCrypto);
+  });
+
+  it("uses the native crypto.randomUUID when available", () => {
+    expect(UuidGenerator.generate()).toMatch(UUID_V4);
+  });
+
+  it("returns unique values across calls", () => {
+    const values = new Set(Array.from({length: 1000}, () => UuidGenerator.generate()));
+    expect(values.size).toBe(1000);
+  });
+
+  it("falls back to getRandomValues when randomUUID is missing", () => {
+    setCrypto({
+      getRandomValues: <T extends ArrayBufferView>(array: T): T => {
+        const view = array as unknown as Uint8Array;
+        for (let i = 0; i < view.length; i++) {
+          view[i] = i;
+        }
+        return array;
+      },
+    });
+
+    const uuid = UuidGenerator.generate();
+    expect(uuid).toMatch(UUID_V4);
+    // Version nibble is forced to 4 and the variant nibble into the 8-b range.
+    expect(uuid[14]).toBe("4");
+    expect(["8", "9", "a", "b"]).toContain(uuid[19].toLowerCase());
+  });
+
+  it("falls back to Math.random when no Web Crypto is present", () => {
+    setCrypto(undefined);
+    expect(UuidGenerator.generate()).toMatch(UUID_V4);
+  });
+});

--- a/packages/common/src/utils/uuid.util.ts
+++ b/packages/common/src/utils/uuid.util.ts
@@ -1,0 +1,57 @@
+/**
+ * Minimal structural type for the slice of the Web Crypto API this utility needs. Declared
+ * locally so the code type-checks regardless of which `lib`/`@types/node` version is in play.
+ */
+interface WebCryptoLike {
+  randomUUID?(): string;
+  getRandomValues?<T extends ArrayBufferView>(array: T): T;
+}
+
+/**
+ * Cross-runtime UUID generation. Replaces Node's `crypto.randomUUID()` with the Web Crypto
+ * API exposed on `globalThis.crypto`, which is available in browsers, Node.js (19+), Deno,
+ * Bun and Cloudflare Workers — keeping `@pristine-ts/common` importable outside Node without
+ * pulling in the Node-only `crypto` module.
+ */
+export class UuidGenerator {
+  /**
+   * Returns an RFC 4122 version 4 UUID. Prefers the native `crypto.randomUUID()`, then
+   * derives one from `crypto.getRandomValues()`, and only as a last resort (no Web Crypto at
+   * all) falls back to `Math.random()` — which is NOT cryptographically secure but keeps
+   * exotic runtimes working rather than throwing.
+   */
+  public static generate(): string {
+    const webCrypto: WebCryptoLike | undefined = (globalThis as { crypto?: WebCryptoLike }).crypto;
+
+    if (typeof webCrypto?.randomUUID === "function") {
+      return webCrypto.randomUUID();
+    }
+
+    if (typeof webCrypto?.getRandomValues === "function") {
+      const bytes = webCrypto.getRandomValues(new Uint8Array(16));
+      // Set the version (4) and variant (RFC 4122) bits.
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+      const hex: string[] = [];
+      for (let i = 0; i < bytes.length; i++) {
+        hex.push(bytes[i].toString(16).padStart(2, "0"));
+      }
+
+      return (
+        hex.slice(0, 4).join("") + "-" +
+        hex.slice(4, 6).join("") + "-" +
+        hex.slice(6, 8).join("") + "-" +
+        hex.slice(8, 10).join("") + "-" +
+        hex.slice(10, 16).join("")
+      );
+    }
+
+    // Last-resort, non-cryptographic fallback.
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+      const random = (Math.random() * 16) | 0;
+      const value = char === "x" ? random : (random & 0x3) | 0x8;
+      return value.toString(16);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Makes `@pristine-ts/common` importable in browsers by removing its two Node-only static imports. Because the package barrel (`common.module.ts`) re-exports everything via `export *`, importing **anything** from `@pristine-ts/common` previously pulled in `crypto` and `async_hooks`, which breaks browser bundlers. Both are now resolved with no change to the public API.

## Changes

### `crypto` → universal Web Crypto (`UuidGenerator`)
`models/span.model.ts` and `models/trace.model.ts` used `randomUUID` from `"crypto"`. Replaced with a new OO `UuidGenerator` util that uses the Web Crypto API on `globalThis.crypto` — available in browsers, Node.js 19+, Deno, Bun and Cloudflare Workers — falling back to `getRandomValues`, then `Math.random`. Universal, no conditional build.

### `async_hooks` → browser export condition
`AsyncLocalStorage` has no browser equivalent. The storage is now extracted behind an `EventContextStorage` interface:
- `managers/event-context.als.ts` — the real Node `AsyncLocalStorage` (behavior unchanged).
- `managers/event-context.als.browser.ts` — a synchronous shim.

The package's `browser` field swaps the compiled `als` module for the browser variant, so bundlers never resolve `async_hooks`. **`EventContextManager`'s public API is identical** — its 14 internal importers are untouched.

The browser shim scopes and restores context synchronously (including nested `run()` and on throw) but cannot propagate across `await` — a limitation no browser API avoids.

## Tests
- Added `UuidGenerator` specs covering all three fallback branches.
- Added specs for the browser storage shim (sync scoping, nesting, restore-on-throw, return value).
- `@pristine-ts/common`: 75 tests pass.

## Verification
- Full monorepo: **37/37 build, 37/37 test, 0 TS errors**; eslint clean on all changed files.
- Confirmed the only remaining `async_hooks` import is the Node `als` module the `browser` field replaces, and the browser-mapped dist files exist for both ESM and CJS.

## Note on bundler support
The `browser` field (object form) is honored by webpack, Vite/Rollup, esbuild and Parcel. If you also need a bundler that only reads `exports` conditions, a matching `exports` map can be added — left out here since it restricts deep imports and is more invasive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7FkAZTRFg4RVDs5bMtCF)_