### PR TITLE
fix(cli): clip select() menu rows to terminal width so they can't wrap

### DIFF
--- a/packages/cli/src/managers/cli-prompt.manager.spec.ts
+++ b/packages/cli/src/managers/cli-prompt.manager.spec.ts
@@ -125,6 +125,40 @@ describe("CliPrompt", () => {
       const prompt = build();
       await expect(prompt.select("Format?", [])).rejects.toThrow();
     });
+
+    // Regression: a label wider than the terminal used to be written in full and wrapped onto a
+    // second screen row. The repaint backs the cursor up by the choice COUNT, so a wrapped row
+    // left it mid-menu and the redraw duplicated/corrupted the list. Every rendered row must now
+    // fit the width so it stays exactly one screen row.
+    it("clips each choice row to the terminal width so a long label never wraps", async () => {
+      const longChoices = [
+        {name: "a-very-long-choice-label-that-would-wrap-the-line", value: "a"},
+        {name: "another-extremely-long-choice-label-goes-here-too", value: "b"},
+      ];
+      const originalColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+      Object.defineProperty(process.stdout, "columns", {value: 20, configurable: true});
+
+      try {
+        await build([DOWN, ENTER]).select("Pick one", longChoices);
+
+        const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "");
+        const rows = (process.stdout.write as jest.Mock).mock.calls
+          .map((call) => stripAnsi(String(call[0])).replace(/\n$/, ""))
+          .filter((line) => /^(?:❯ |\s{2})\S/.test(line)); // rendered choice rows only
+
+        expect(rows.length).toBeGreaterThan(0);
+        for (const row of rows) {
+          expect(row.length).toBeLessThanOrEqual(20 - 1); // never reaches the edge -> never wraps
+        }
+        expect(rows.some((row) => row.endsWith("…"))).toBe(true); // proof the clip engaged
+      } finally {
+        if (originalColumns) {
+          Object.defineProperty(process.stdout, "columns", originalColumns);
+        } else {
+          delete (process.stdout as {columns?: number}).columns;
+        }
+      }
+    });
   });
 
   describe("readSecret", () => {

--- a/packages/cli/src/managers/cli-prompt.manager.ts
+++ b/packages/cli/src/managers/cli-prompt.manager.ts
@@ -181,25 +181,40 @@ export class CliPrompt {
 
   /**
    * Writes the choice rows, highlighting the active one with a colored pointer. Each row is
-   * cleared before it's written so a repaint never leaves a longer previous label behind.
+   * cleared before it's written (so a repaint never leaves a longer previous label behind) and
+   * clipped to the terminal width by {@link formatChoiceRow} (so a row never wraps — see there).
    * @private
    */
   private renderChoices<T>(choices: {name: string; value: T}[], active: number): void {
     choices.forEach((choice, index) => {
       clearLine(process.stdout, 0);
       cursorTo(process.stdout, 0);
-
-      if (index === active) {
-        process.stdout.write(`${CliPrompt.CYAN}${CliPrompt.POINTER} ${choice.name}${CliPrompt.RESET}\n`);
-      } else {
-        process.stdout.write(`  ${choice.name}\n`);
-      }
+      process.stdout.write(`${this.formatChoiceRow(choice.name, index === active)}\n`);
     });
   }
 
   /**
-   * Moves the cursor back up over the previously-rendered choice rows and rewrites them, so
-   * the menu updates in place as the selection moves.
+   * Builds one choice row — `❯ <name>` for the active row, `  <name>` otherwise — CLIPPED to the
+   * terminal width so a label longer than the terminal can't wrap onto a second screen row.
+   * {@link repaintChoices} backs the cursor up by the choice COUNT, which only lands on the first
+   * row if every choice occupies exactly one screen row; a wrapped row desyncs that count and the
+   * redraw duplicates (and, via the per-row clear, corrupts) the menu. The colour codes are
+   * zero-width, so the visible text is clipped first and then wrapped in colour; `- 1` keeps the
+   * row one column short of the edge, dodging the terminal's last-column "pending wrap".
+   * @private
+   */
+  private formatChoiceRow(name: string, isActive: boolean): string {
+    const text = `${isActive ? `${CliPrompt.POINTER} ` : "  "}${name}`;
+    const width = Math.max(1, (process.stdout.columns || 80) - 1);
+    const clipped = text.length > width ? `${text.slice(0, width - 1)}…` : text;
+    return isActive ? `${CliPrompt.CYAN}${clipped}${CliPrompt.RESET}` : clipped;
+  }
+
+  /**
+   * Moves the cursor back up over the previously-rendered choice rows and rewrites them, so the
+   * menu updates in place as the selection moves. Relies on every choice occupying exactly one
+   * screen row — guaranteed by {@link formatChoiceRow}'s width clip — so `-choices.length` lands
+   * back on the first row.
    * @private
    */
   private repaintChoices<T>(choices: {name: string; value: T}[], active: number): void {


### PR DESCRIPTION
## The bug

`CliPrompt.select`'s arrow-key menu **duplicates and garbles itself** on the first keypress — but only on terminals narrow enough that a choice label is wider than the screen.

## Root cause

`select` repaints in place: `repaintChoices` backs the cursor up by the **choice count** (`moveCursor(0, -choices.length)`) and rewrites. That assumes **one screen row per choice**. When a label is wider than the terminal it **wraps onto a second screen row**, so the cursor-up moves too few rows, lands in the middle of the menu, and `renderChoices` redraws over a mismatched region — duplicating the list and, because each row is `clearLine`'d individually, leaving spliced garbage.

It renders cleanly on a wide terminal (one row per choice), which is why it slipped through — and the spec mocks `process.stdout.write`, so no test exercised real wrapping.

Reproduced with the real prompt in a 24-column terminal:

```
❯ Set up / update this m
achine
  GitHub Actions deploy
targets
  Set up / update this m      <- duplicate begins
achineaccess for a perso      <- per-row clearLine garbage
❯ GitHub Actions deploy
...
```

## The fix

Add `formatChoiceRow()`, which clips each row's **visible** text to `columns - 1` (with a `…`) before wrapping it in colour, so every choice occupies exactly one screen row and the `-choices.length` repaint maths always hold. The trailing-newline repaint strategy is left intact (it is correct at the bottom of the screen — verified).

## Verification

- **New regression test**: with `columns = 20`, asserts no rendered row exceeds the width and that clipping actually engages (fails on the old code).
- Full `@pristine-ts/cli` suite green (148 tests).
- Drove the **real** built `CliPrompt.select` with real arrow keys in narrow tmux panes, including at the bottom of the screen — clean, clipped, no duplication or corruption.

> Note: a local `npm run build` in this checkout trips a pre-existing `ignoreDeprecations` (TS5103) error because its `node_modules` still has TypeScript 5.9.3 while `master` moved to TS 6.0 (`build(ts6)`); an untouched package fails identically. CI's `npm ci` installs TS 6.0 and builds clean. The change is trivial TypeScript and type-checks under both.

Context: the same class of bug was independently worked around in the `valet` CLI's own menu; this fixes it at the source, so any `@commandParameter` `choices` menu (and any direct `CliPrompt.select` caller) benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
