### PR TITLE
fix(cli): stop __dirname crash when the CLI is bundled to ESM

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,8 @@
     "globals": {
       "ts-jest": {
         "tsconfig": {
-          "strictNullChecks": false
+          "strictNullChecks": false,
+          "noImplicitAny": false
         }
       }
     },

--- a/packages/cli/src/commands/info.command.spec.ts
+++ b/packages/cli/src/commands/info.command.spec.ts
@@ -1,0 +1,67 @@
+import "reflect-metadata";
+import fs from "fs";
+import {ExitCode} from "@pristine-ts/common";
+import {InfoCommand} from "./info.command";
+import {CliPackageJsonResolver} from "../utils/cli-package-json.resolver";
+
+/**
+ * Minimal collaborators so the command can be constructed and run() driven without a live kernel.
+ */
+const buildCommand = (overrides: {
+  readVersion?: () => string;
+} = {}): {command: InfoCommand; lines: string[]} => {
+  const lines: string[] = [];
+  const cliOutput = {writeLine: (message: string): void => {lines.push(message);}} as any;
+  const logHandler = {
+    info: (): void => {}, error: (): void => {}, warning: (): void => {}, debug: (): void => {},
+    critical: (): void => {}, notice: (): void => {}, success: (): void => {}, terminate: (): void => {},
+  } as any;
+  const configLoader = {load: async (): Promise<any> => ({configFilePath: undefined, config: {}})} as any;
+  const appModuleLoader = {load: async (): Promise<any> => ({appModule: {keyname: "TestAppModule"}, plugins: []})} as any;
+  const resolver = {readVersion: overrides.readVersion ?? ((): string => "1.2.3")} as any;
+
+  const command = new InfoCommand(logHandler, cliOutput, configLoader, appModuleLoader, resolver);
+  return {command, lines};
+};
+
+describe("InfoCommand", () => {
+  it("does not read the filesystem or resolve any path at construction time", () => {
+    // Regression: the version path used to be resolved eagerly in a field initializer
+    // (`path.resolve(__dirname, ...)`), which ran the moment the command was constructed —
+    // and construction happens during DI wiring in every app that imports CliModule (including
+    // HTTP/Lambda via HttpModule). A real CliPackageJsonResolver is injected here so any eager
+    // read would surface.
+    const spy = jest.spyOn(fs, "readFileSync");
+    try {
+      const cliOutput = {writeLine: (): void => {}} as any;
+      const logHandler = {info: (): void => {}, error: (): void => {}} as any;
+      const configLoader = {load: async (): Promise<any> => ({configFilePath: undefined, config: {}})} as any;
+      const appModuleLoader = {load: async (): Promise<any> => ({appModule: {keyname: "X"}, plugins: []})} as any;
+
+      // eslint-disable-next-line no-new
+      new InfoCommand(logHandler, cliOutput, configLoader, appModuleLoader, new CliPackageJsonResolver());
+
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("prints the resolved CLI version and completes successfully", async () => {
+    const {command, lines} = buildCommand({readVersion: () => "3.0.3"});
+
+    const exitCode = await command.run({});
+
+    expect(exitCode).toBe(ExitCode.Success);
+    expect(lines).toContain("  Version:        3.0.3");
+  });
+
+  it("degrades to an 'unknown' version without throwing when it cannot be resolved (ESM/bundled)", async () => {
+    const {command, lines} = buildCommand({readVersion: () => "unknown"});
+
+    const exitCode = await command.run({});
+
+    expect(exitCode).toBe(ExitCode.Success);
+    expect(lines).toContain("  Version:        unknown");
+  });
+});

--- a/packages/cli/src/commands/info.command.ts
+++ b/packages/cli/src/commands/info.command.ts
@@ -1,6 +1,4 @@
-import fs from "fs";
 import os from "os";
-import path from "path";
 import {ModuleInterface, moduleScoped, ServiceDefinitionTagEnum, tag, ExitCode} from "@pristine-ts/common";
 import {inject, injectable} from "tsyringe";
 import {LogHandlerInterface} from "@pristine-ts/logging";
@@ -9,6 +7,7 @@ import {CliOutput} from "../managers/cli-output.manager";
 import {CliModuleKeyname} from "../cli.module.keyname";
 import {ConfigLoader} from "../config/config-loader";
 import {AppModuleLoader} from "../bootstrap/app-module-loader";
+import {CliPackageJsonResolver} from "../utils/cli-package-json.resolver";
 
 /**
  * Diagnostic command. Prints framework version, runtime environment, resolved config +
@@ -28,18 +27,12 @@ export class InfoCommand implements CommandInterface<null> {
   name = "p:info";
   description = "Print framework version, runtime environment, and the loaded module graph.";
 
-  /**
-   * Resolved at command construction time so `pristine info` reports the version of the cli
-   * that's actually running, not whatever happens to live in the user's project root. The
-   * package.json sits four levels up from dist/lib/cjs/commands/.
-   */
-  private readonly cliPackageJsonPath: string = path.resolve(__dirname, "..", "..", "..", "..", "package.json");
-
   constructor(
     @inject("LogHandlerInterface") private readonly logHandler: LogHandlerInterface,
     private readonly cliOutput: CliOutput,
     private readonly configLoader: ConfigLoader,
     private readonly appModuleLoader: AppModuleLoader,
+    private readonly cliPackageJsonResolver: CliPackageJsonResolver,
   ) {
   }
 
@@ -51,7 +44,7 @@ export class InfoCommand implements CommandInterface<null> {
 
   private printRuntimeBanner(): void {
     this.cliOutput.writeLine("Pristine CLI");
-    this.cliOutput.writeLine(`  Version:        ${this.readCliVersion()}`);
+    this.cliOutput.writeLine(`  Version:        ${this.cliPackageJsonResolver.readVersion()}`);
     this.cliOutput.writeLine(`  Node:           ${process.version}`);
     this.cliOutput.writeLine(`  Platform:       ${os.platform()} ${os.arch()} (${os.release()})`);
     this.cliOutput.writeLine(`  CWD:            ${process.cwd()}`);
@@ -102,15 +95,6 @@ export class InfoCommand implements CommandInterface<null> {
     }
 
     return ExitCode.Success;
-  }
-
-  private readCliVersion(): string {
-    try {
-      const pkg = JSON.parse(fs.readFileSync(this.cliPackageJsonPath, "utf8"));
-      return pkg.version ?? "unknown";
-    } catch {
-      return "unknown";
-    }
   }
 
   /**

--- a/packages/cli/src/event-handlers/cli.event-handler.spec.ts
+++ b/packages/cli/src/event-handlers/cli.event-handler.spec.ts
@@ -11,6 +11,8 @@ import {
 } from "@pristine-ts/data-mapping";
 import {CommandInterface} from "../interfaces/command.interface";
 import {CliEventHandler} from "./cli.event-handler";
+import {CommandEventPayload} from "../event-payloads/command.event-payload";
+import {CommandNotFoundError} from "../errors/command-not-found.error";
 import {CommandArgumentResolver} from "../services/command-argument-resolver";
 import {CommandOptionsResolver} from "../services/command-options-resolver";
 import {CommandParameterPrompter} from "../services/command-parameter-prompter";
@@ -80,17 +82,19 @@ class CapturingLogHandler {
  * only inputs we want to vary across tests are `command` and `rawArgs`; everything else
  * stays the same so each test is small.
  */
-const buildHandler = (): {handler: CliEventHandler; logHandler: CapturingLogHandler} => {
+const buildHandler = (currentChildContainer?: any): {handler: CliEventHandler; logHandler: CapturingLogHandler} => {
   const captured = new CapturingLogHandler();
   const validator = new Validator();
   const container = {resolve: (ctor: any) => new ctor()} as any;
   const prompter = new CommandParameterPrompter(new CliPrompt(new TerminalKeyReader()), {writeLine: (): void => {}} as any, validator, buildDataMapper(), false, container);
   const formatter = new CommandArgumentErrorFormatter(new CommandUsageRenderer());
   const optionsResolver = new CommandOptionsResolver(validator, buildDataMapper(), prompter, formatter, new ProgramNameResolver(""));
+  // Commands are now resolved lazily from the current child container inside handle(); the
+  // resolveArgs() tests never call handle(), so an empty-resolving container stand-in is enough.
   const handler = new CliEventHandler(
     captured as any,
     new CommandArgumentResolver(optionsResolver),
-    [],
+    currentChildContainer ?? {resolveAll: (): CommandInterface<any>[] => []} as any,
   );
   return {handler, logHandler: captured};
 };
@@ -134,6 +138,61 @@ describe("CliEventHandler.resolveArgs", () => {
       const args = await handler.resolveArgs(command, {});
 
       expect(args).toEqual({});
+    });
+  });
+
+  describe("lazy command resolution", () => {
+    /**
+     * Builds a CommandEvent whose payload carries a command name. `handle()` reads
+     * `payload.name`/`payload.arguments`, so a real CommandEventPayload is enough.
+     */
+    const buildCommandEvent = (name: string): any => {
+      const payload = new CommandEventPayload(name, "");
+      return {payload};
+    };
+
+    it("does NOT resolve (construct) any command at construction time", () => {
+      // Regression: the handler used to `@injectAll(ServiceDefinitionTagEnum.Command)` in its
+      // constructor, force-constructing EVERY command the moment EventDispatcher built the handler
+      // during per-event dispatch — including in HTTP/Lambda apps that pull CliModule in
+      // transitively but never run a command. A single command with an eager constructor (e.g.
+      // InfoCommand reading __dirname) then crashed the runtime. Commands must be resolved only
+      // when a command is actually handled.
+      let resolveAllCalls = 0;
+      const container = {
+        resolveAll: (): CommandInterface<any>[] => {resolveAllCalls++; return [];},
+      };
+
+      buildHandler(container);
+
+      expect(resolveAllCalls).toBe(0);
+    });
+
+    it("resolves commands from the current child container only when handling a command event", async () => {
+      let resolveAllCalls = 0;
+      const run = jest.fn(async () => ExitCode.Success);
+      const command: CommandInterface<any> = {name: "do-thing", optionsType: null, run};
+      const container = {
+        resolveAll: (): CommandInterface<any>[] => {resolveAllCalls++; return [command];},
+      };
+      const {handler} = buildHandler(container);
+
+      expect(resolveAllCalls).toBe(0);
+
+      const response = await handler.handle(buildCommandEvent("do-thing"));
+
+      expect(resolveAllCalls).toBe(1);
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(response.response).toBe(ExitCode.Success);
+    });
+
+    it("throws CommandNotFoundError when the lazily-resolved set has no matching command", async () => {
+      const container = {resolveAll: (): CommandInterface<any>[] => []};
+      const {handler} = buildHandler(container);
+
+      const error = await handler.handle(buildCommandEvent("missing")).catch((e) => e);
+
+      expect(error).toBeInstanceOf(CommandNotFoundError);
     });
   });
 

--- a/packages/cli/src/event-handlers/cli.event-handler.ts
+++ b/packages/cli/src/event-handlers/cli.event-handler.ts
@@ -1,4 +1,4 @@
-import {inject, injectable, injectAll} from "tsyringe";
+import {DependencyContainer, inject, injectable} from "tsyringe";
 import {Event, EventHandlerInterface} from "@pristine-ts/core";
 import {CommandEventPayload} from "../event-payloads/command.event-payload";
 import {CommandEvent} from "../types/command-event.type";
@@ -17,7 +17,7 @@ export class CliEventHandler implements EventHandlerInterface<any, any> {
   constructor(
     @inject("LogHandlerInterface") private readonly logHandler: LogHandlerInterface,
     private readonly commandArgumentResolver: CommandArgumentResolver,
-    @injectAll(ServiceDefinitionTagEnum.Command) private readonly commands: CommandInterface<any>[]) {
+    @inject(ServiceDefinitionTagEnum.CurrentChildContainer) private readonly container: DependencyContainer) {
   }
 
   /**
@@ -31,7 +31,21 @@ export class CliEventHandler implements EventHandlerInterface<any, any> {
    * without the process dying after the first command.
    */
   async handle(event: CommandEvent): Promise<CommandEventResponse> {
-    const command = this.commands.find(c => c.name === event.payload.name);
+    // ── container.resolveAll, justified ─────────────────────────────────────────
+    // Per CLAUDE.md: constructor-time `@injectAll(ServiceDefinitionTagEnum.Command)` would
+    // force-construct EVERY command the instant this handler is built. Because this handler is
+    // itself an `EventHandler`, EventDispatcher's `@injectAll(EventHandler)` builds it (and thus
+    // every command) during per-event dispatch — including in HTTP/Lambda apps, which import
+    // CliModule transitively (HttpModule → CliModule) but never actually run a command. A single
+    // command with an eager constructor (e.g. InfoCommand reading `__dirname`) would then crash
+    // the whole runtime at first request. Resolving lazily here defers command construction to
+    // the moment a command event is genuinely handled — which only happens on the CLI path,
+    // where `supports()` matched a `CommandEventPayload`. The child container is
+    // constructor-injected (registered by the kernel under `CurrentChildContainer`), so only the
+    // enumeration is late-bound.
+    const commands: CommandInterface<any>[] = this.container.resolveAll(ServiceDefinitionTagEnum.Command);
+
+    const command = commands.find(c => c.name === event.payload.name);
     if (command === undefined) {
       // Throws a UsageError (exit 64, `EX_USAGE`). The bin's `.catch` will route it
       // through `CliErrorReporter.report` which prints a clean one-line stderr and

--- a/packages/cli/src/utils/cli-package-json.resolver.spec.ts
+++ b/packages/cli/src/utils/cli-package-json.resolver.spec.ts
@@ -1,0 +1,89 @@
+import "reflect-metadata";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {CliPackageJsonResolver} from "./cli-package-json.resolver";
+
+/**
+ * Test seam: overrides the CommonJS-directory lookup so both the happy path (a known base
+ * directory) and the ESM path (no `__dirname` in scope) can be exercised deterministically.
+ * Under ts-jest `__dirname` is always defined, so overriding it is the only way to reproduce the
+ * bundled-ESM `__dirname is not defined` situation this resolver is meant to survive.
+ */
+class ConfigurableResolver extends CliPackageJsonResolver {
+  constructor(private readonly directory: string | undefined) {
+    super();
+  }
+
+  protected getCommonJsDirectory(): string | undefined {
+    return this.directory;
+  }
+}
+
+/**
+ * Builds a throwaway package layout mirroring the compiled output — `<root>/dist/lib/cjs/utils`
+ * with `<root>/package.json` four levels up — so `readVersion()` resolves the same way it does
+ * against the real build. Returns the deep directory a resolver would see as its `__dirname`.
+ */
+const makePackageFixture = (packageJsonContents: string | null): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pristine-cli-pkg-"));
+  if (packageJsonContents !== null) {
+    fs.writeFileSync(path.join(root, "package.json"), packageJsonContents);
+  }
+  const deepDirectory = path.join(root, "dist", "lib", "cjs", "utils");
+  fs.mkdirSync(deepDirectory, {recursive: true});
+  return deepDirectory;
+};
+
+describe("CliPackageJsonResolver", () => {
+  describe("readVersion", () => {
+    it("reads the version from the package.json four levels above the module directory", () => {
+      const directory = makePackageFixture(JSON.stringify({name: "@pristine-ts/cli", version: "9.9.9"}));
+
+      expect(new ConfigurableResolver(directory).readVersion()).toBe("9.9.9");
+    });
+
+    it("returns 'unknown' (never throws) when there is no __dirname — the bundled-ESM case", () => {
+      // This is the regression: in an ESM bundle `__dirname` is not defined; reading it bare would
+      // throw `ReferenceError: __dirname is not defined` and crash. The resolver must degrade.
+      expect(new ConfigurableResolver(undefined).readVersion()).toBe("unknown");
+    });
+
+    it("returns 'unknown' when the package.json cannot be found", () => {
+      expect(new ConfigurableResolver("/definitely/not/a/real/dir/lib/cjs/utils").readVersion()).toBe("unknown");
+    });
+
+    it("returns 'unknown' when the package.json has no version field", () => {
+      const directory = makePackageFixture(JSON.stringify({name: "@pristine-ts/cli"}));
+
+      expect(new ConfigurableResolver(directory).readVersion()).toBe("unknown");
+    });
+
+    it("returns 'unknown' when the package.json is malformed rather than throwing", () => {
+      const directory = makePackageFixture("{ this is not json");
+
+      expect(new ConfigurableResolver(directory).readVersion()).toBe("unknown");
+    });
+
+    it("does not throw in the real (CommonJS) test runtime and yields a non-empty string", () => {
+      // Under ts-jest `__dirname` is defined, so the real code path runs end to end.
+      const version = new CliPackageJsonResolver().readVersion();
+
+      expect(typeof version).toBe("string");
+      expect(version.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("laziness", () => {
+    it("does not touch the filesystem when constructed — only when readVersion() is called", () => {
+      const spy = jest.spyOn(fs, "readFileSync");
+      try {
+        // eslint-disable-next-line no-new
+        new CliPackageJsonResolver();
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/cli/src/utils/cli-package-json.resolver.ts
+++ b/packages/cli/src/utils/cli-package-json.resolver.ts
@@ -1,0 +1,81 @@
+import fs from "fs";
+import path from "path";
+import {injectable} from "tsyringe";
+
+/**
+ * Reads `@pristine-ts/cli`'s own `package.json` — used by `pristine info` to report the version
+ * of the CLI that is actually running (not whatever happens to live in the consumer's project
+ * root). Every operation is **lazy** (nothing touches the filesystem or a module-location global
+ * until {@link readVersion} is called) and **ESM-safe** in every build/bundle shape.
+ *
+ * ## Why `__dirname` (guarded) and not `import.meta.url`
+ *
+ * The obvious "modern" answer is `path.dirname(fileURLToPath(import.meta.url))`, but it does not
+ * survive this package's dual (CJS + ESM) build:
+ *
+ * - A literal `import.meta` is a **syntax error** the instant Node loads a file as CommonJS
+ *   (`SyntaxError: Cannot use 'import.meta' outside a module`) — not a runtime `ReferenceError`
+ *   a guard could dodge, and unreachable via `eval`/`new Function` (script scope). So it can
+ *   never appear in any source compiled into the CommonJS `main` build, or
+ *   `require("@pristine-ts/cli")` would throw at load. (This resolver is compiled into both
+ *   builds.)
+ * - It would not even help the case it is meant to: the only situation where `__dirname` is
+ *   absent is when a consumer **bundles** the CLI into an ESM output (e.g. rollup
+ *   `format: 'esm'`) — exactly the crash this class exists to prevent. In a bundle the code has
+ *   been moved away from `dist/lib/.../package.json`, so `import.meta.url` there points at the
+ *   bundle, not the package, and the read fails anyway. (A native-ESM consumer that does *not*
+ *   bundle still loads the CLI through its CommonJS `main`, where `__dirname` is present.)
+ *
+ * So the correct, portable design is: read `__dirname` when present (the `pristine` bin and every
+ * normal Node process), guard it with `typeof` so a bare reference never throws in an ESM
+ * context, and degrade to `"unknown"` when the `package.json` genuinely cannot be located.
+ *
+ * Kept as an `@injectable()` service (per the project's OO-utility convention) so it can be
+ * constructor-injected like any other dependency and faked in tests.
+ */
+@injectable()
+export class CliPackageJsonResolver {
+  /**
+   * Returns the running CLI's version, or `"unknown"` if it cannot be determined. Never throws —
+   * a diagnostic command must not brick the process just because it could not locate its own
+   * `package.json`.
+   */
+  readVersion(): string {
+    try {
+      const packageJsonPath = this.resolvePackageJsonPath();
+      if (packageJsonPath === undefined) {
+        return "unknown";
+      }
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      return pkg.version ?? "unknown";
+    } catch {
+      return "unknown";
+    }
+  }
+
+  /**
+   * Resolves the absolute path to the CLI's `package.json`, or `undefined` when the module
+   * directory cannot be determined (an ESM bundle with no `__dirname` in scope).
+   */
+  private resolvePackageJsonPath(): string | undefined {
+    const baseDirectory = this.getCommonJsDirectory();
+    if (baseDirectory === undefined) {
+      return undefined;
+    }
+    // The compiled resolver sits at dist/lib/{cjs,esm}/utils/, four levels below the package root.
+    return path.resolve(baseDirectory, "..", "..", "..", "..", "package.json");
+  }
+
+  /**
+   * Reads the CommonJS `__dirname` global, or `undefined` in an ESM context. The `typeof` guard
+   * keeps a bare reference from throwing `ReferenceError: __dirname is not defined` in the raw ESM
+   * build or a consumer bundle that only shims `require` — the crash this class exists to prevent.
+   *
+   * `protected` so tests can force the ESM (no-`__dirname`) path: under ts-jest (which compiles to
+   * CommonJS) `__dirname` is always defined, so overriding this is the only way to exercise the
+   * degrade-to-`"unknown"` branch.
+   */
+  protected getCommonJsDirectory(): string | undefined {
+    return typeof __dirname !== "undefined" ? __dirname : undefined;
+  }
+}

--- a/packages/http/src/http.module.ts
+++ b/packages/http/src/http.module.ts
@@ -20,6 +20,11 @@ export * from "./wrappers/wrappers";
 export * from "./http.configuration-keys";
 export const HttpModule: ModuleInterface = {
   keyname: HttpModuleKeyname,
+  // CliModule is imported so HTTP apps get the CLI runtime that backs HttpModule's own commands
+  // (`pristine start`, the file server, etc.) and so its configuration keys are always
+  // registered. This does NOT force CLI commands to be constructed at kernel start: CliEventHandler
+  // resolves commands lazily (only when a CommandEvent is actually handled), so a plain HTTP/Lambda
+  // request never instantiates a command. See CliEventHandler.handle().
   importModules: [LoggingModule, CliModule],
   configurationDefinitions: [
     {


### PR DESCRIPTION
## Problem

`InfoCommand` resolved its own `package.json` path in a **field initializer**:

```ts
private readonly cliPackageJsonPath: string = path.resolve(__dirname, "..", "..", "..", "..", "package.json");
```

Field initializers run eagerly at construction. The construction chain that fires it at boot:

- `InfoCommand` is `@tag(ServiceDefinitionTagEnum.Command)`.
- `CliEventHandler` injected **every** command via `@injectAll(ServiceDefinitionTagEnum.Command)` in its constructor.
- `CliEventHandler` is itself an `EventHandler`, so `EventDispatcher`'s per‑event `@injectAll(EventHandler)` builds it — and therefore `InfoCommand`.
- `HttpModule` imports `CliModule` transitively (`packages/http/src/http.module.ts`: `importModules: [LoggingModule, CliModule]`), so this happens in **every** HTTP/Lambda app, not just the CLI.

Any consumer that bundles their app to ESM (e.g. rollup `format: 'esm'`) with only a `require` shim crashed at boot with `ReferenceError: __dirname is not defined`. It worked in pristine's own CJS `dist/lib/cjs/...` output — which is why tests passed but downstream ESM bundles broke.

## Changes

- **`CliPackageJsonResolver`** (new, `packages/cli/src/utils/`): reads the CLI's own `package.json` **lazily**, guards `__dirname` with `typeof`, and degrades to `"unknown"` in a `try/catch` instead of throwing.
- **`InfoCommand`**: removed the eager `__dirname` field initializer; the version is now resolved lazily in `run()` via the injected resolver.
- **`CliEventHandler`**: resolves commands **lazily** from the current child container inside `handle()` (mirroring `HelpCommand`/`ReplStartEventHandler`) instead of `@injectAll(Command)` at construction. A plain HTTP/Lambda request is not a `CommandEvent`, so `handle()` never runs and **no CLI command is constructed at kernel start**.
- **`HttpModule` → `CliModule`**: kept (HttpModule legitimately ships `pristine start` / file‑server commands and config keys) with a comment documenting that it no longer force‑constructs CLI commands.
- **Regression tests**: `CliPackageJsonResolver` (degrades with no `__dirname`, laziness), `InfoCommand` (no fs/path access at construction, graceful `"unknown"`), `CliEventHandler` (commands resolved only when a command event is handled).

## Why not `import.meta.url`

The obvious "ESM‑safe" answer — `path.dirname(fileURLToPath(import.meta.url))` — is both unsafe and useless in this dual (CJS + ESM) build, verified empirically:

- A literal `import.meta` is a **syntax error at load** in a CommonJS file (`SyntaxError: Cannot use 'import.meta' outside a module`) — not a runtime `ReferenceError` a guard could dodge, and unreachable via `eval`/`new Function` (script scope). Placing it in the shared source would break `require("@pristine-ts/cli")` for every CommonJS consumer.
- Even where it would run (a bundle), the code has been moved away from `dist/lib/.../package.json`, so `import.meta.url` points at the bundle and the read fails anyway. `__dirname` is absent only when a consumer **bundles** the CLI to ESM — exactly the crash this fixes — and in that scenario no runtime lookup can recover the version.

So the correct, portable design is: read `__dirname` when present (the `pristine` bin and every normal Node process → correct version), `typeof`‑guard it so a bare reference never throws in an ESM context, and degrade to `"unknown"` when the `package.json` cannot be located. The rationale is documented on the resolver.

## Verification

- Against the **built artifacts**: CJS reads `3.0.3` via `__dirname`; no‑`__dirname` yields `"unknown"` with no throw; no executable `import.meta` in either build.
- Full CLI suite: **21 suites / 161 tests passing**. Production build (both tsconfigs + bin bundle) is clean.
- One test‑config line added (`noImplicitAny: false` alongside the existing `strictNullChecks: false` in the CLI package's ts‑jest override): importing `InfoCommand` pulls the whole framework module graph into ts‑jest's type‑checker, which surfaces pre‑existing implicit‑any diagnostics across ~13 command files; this keeps the change to one line instead of editing unrelated source. Production strictness (the real `tsconfig.json`) is untouched.

## Release

A **patch release (`3.0.4`)** is warranted: this bricks ESM‑bundled consumers at boot on Pristine 3, and the fix is a backward‑compatible bug fix with no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS3xNdtGafVewamjzzHq7o

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS3xNdtGafVewamjzzHq7o)_