### PR TITLE
docs: label the CLI/HTTP changelog entries 3.0.5

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog — @pristine-ts/cli
 
-## Unreleased (proposed 3.1.0 — minor)
+## 3.0.5
 
 Hardening of `@pristine-ts/cli` for ESM / bundled runtimes, following the `__dirname is not
-defined` boot crash fixed in 3.0.4. A **minor** release is recommended (rather than a patch)
-because the `HttpModule → CliModule` decoupling changes one observable default for HTTP/Lambda
-apps — see the migration note below.
+defined` boot crash fixed in 3.0.4. Note that the `HttpModule → CliModule` decoupling changes one
+observable default for HTTP/Lambda apps — see the migration note below.
 
 ### Fixed / Changed
 

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog — @pristine-ts/http
 
-## Unreleased (proposed 3.1.0 — minor)
+## 3.0.5
 
 - **`HttpModule` no longer imports `CliModule`.** It now imports only the framework modules it
   genuinely uses (`Core`, `DataMapping`, `Logging`, `Observability`, `Validation`), dropping the


### PR DESCRIPTION
Corrects the `@pristine-ts/cli` and `@pristine-ts/http` changelog entries that were headed "Unreleased (proposed 3.1.0 — minor)". The release process is patch-only (`lerna version patch`, fixed mode), so the ESM/bundled-runtime hardening actually shipped in **3.0.5** — not a minor. This relabels both entries to `## 3.0.5` and drops the minor-release recommendation.

The HTTP migration note (console logging default `Pretty` → `Json`) is unchanged — it still applies.

No code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS3xNdtGafVewamjzzHq7o