### PR TITLE
feat(http): config-driven CORS + preflight support in KernelHttpServer

### DIFF
--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — @pristine-ts/http
 
+## 4.0.3
+
+- **Config-driven CORS + preflight support in `KernelHttpServer`.** A browser-facing Pristine
+  server can now handle CORS entirely from configuration — no adapter or middleware. A new
+  `CorsRequestHandler` collaborator is consulted inside `KernelHttpServer.handleRequest`, *before*
+  `kernel.handle()`, so it can answer an `OPTIONS` preflight (`204`, short-circuited before routing)
+  and reject a bad `Host` without the networking `Router` ever running.
+
+  New optional keys under `pristine.http.cors.*` (see `HttpConfigurationKeys`):
+  `allowed-origins` (exact-match allowlist; array or comma string), `allowed-methods`
+  (default `GET,POST,PUT,DELETE,PATCH,OPTIONS`), `allowed-headers` (default `Content-Type`),
+  `exposed-headers`, `max-age` (default `600`), `allow-credentials` (default `false`),
+  `allow-private-network` (Chrome Private Network Access; default `false`), and `allowed-hosts`
+  (optional `Host` allowlist → `403` before routing, a loopback DNS-rebinding defense).
+
+  **CORS is inactive unless configured** — a server with no `cors.*` config behaves exactly as
+  before. `Access-Control-Allow-Origin` is echoed (never `*`, never an arbitrary reflected origin)
+  on both success and error (4xx/5xx) responses for allow-listed origins, so the browser can read
+  error bodies.
+
 ## 3.0.5
 
 - **`HttpModule` no longer imports `CliModule`.** It now imports only the framework modules it

--- a/packages/http/src/cors/cors-preflight-response.interface.ts
+++ b/packages/http/src/cors/cors-preflight-response.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * The answer `CorsRequestHandler` produces for a CORS preflight that must be short-circuited
+ * before routing. `KernelHttpServer` writes `statusCode` and `headers` straight to the
+ * `ServerResponse` without ever invoking `kernel.handle()` — a preflight never corresponds to a
+ * real route.
+ */
+export interface CorsPreflightResponseInterface {
+  /**
+   * The status code to write. Always `204 No Content` for a preflight.
+   */
+  statusCode: number;
+
+  /**
+   * The response headers to write. Populated with the `Access-Control-*` set when the origin is
+   * allow-listed; an empty object when it is not (the browser then blocks for lack of an
+   * `Access-Control-Allow-Origin`, and we never reflect an arbitrary origin or emit `"*"`).
+   */
+  headers: { [name: string]: string };
+}

--- a/packages/http/src/cors/cors-request-context.interface.ts
+++ b/packages/http/src/cors/cors-request-context.interface.ts
@@ -1,0 +1,41 @@
+/**
+ * The normalized, transport-agnostic view of a request that `CorsRequestHandler` needs to make
+ * a CORS decision. Extracted from Node's `IncomingMessage` (via `CorsRequestHandler.buildContext`)
+ * so the decision logic can be unit-tested without a live socket or a Node request object.
+ */
+export interface CorsRequestContextInterface {
+  /**
+   * The upper-cased HTTP method (e.g. `"GET"`, `"OPTIONS"`).
+   */
+  method: string;
+
+  /**
+   * The `Origin` request header, if present. Absent for same-origin and non-browser callers.
+   */
+  origin?: string;
+
+  /**
+   * The `Host` request header, if present. Compared against the `allowed-hosts` allowlist as a
+   * DNS-rebinding defense for loopback servers.
+   */
+  host?: string;
+
+  /**
+   * The `Access-Control-Request-Method` preflight header. Its presence on an `OPTIONS` request
+   * is what distinguishes a CORS preflight from an ordinary `OPTIONS`.
+   */
+  accessControlRequestMethod?: string;
+
+  /**
+   * The `Access-Control-Request-Headers` preflight header, listing the headers the actual
+   * request intends to send.
+   */
+  accessControlRequestHeaders?: string;
+
+  /**
+   * `true` when the request carried `Access-Control-Request-Private-Network: true` — the Chrome
+   * Private Network Access preflight signal emitted when a public/secure context targets a more
+   * private address space (e.g. a loopback daemon).
+   */
+  accessControlRequestPrivateNetwork: boolean;
+}

--- a/packages/http/src/cors/cors-request.handler.spec.ts
+++ b/packages/http/src/cors/cors-request.handler.spec.ts
@@ -1,0 +1,299 @@
+import "reflect-metadata";
+import {CorsRequestHandler} from "./cors-request.handler";
+import {CorsRequestContextInterface} from "./cors-request-context.interface";
+
+/**
+ * Unit coverage for the pure CORS decision engine. `CorsRequestHandler` is constructed directly
+ * with raw config values (exactly the shape `@injectConfig` would inject), so the whole matrix —
+ * allowed vs disallowed origin, preflight vs simple, PNA on/off, host hit/miss, credentials on/off,
+ * header echo — is exercised without a live socket.
+ */
+describe("CorsRequestHandler", () => {
+  const ALLOWED_ORIGIN = "https://app.example.com";
+  const OTHER_ORIGIN = "https://evil.example.com";
+
+  /**
+   * Builds a handler with the module's documented defaults, overridable per-test. The positional
+   * argument order mirrors the constructor's `@injectConfig` parameters.
+   */
+  const makeHandler = (overrides: Partial<{
+    allowedOrigins: string | string[];
+    allowedMethods: string | string[];
+    allowedHeaders: string | string[];
+    exposedHeaders: string | string[];
+    maxAge: number;
+    allowCredentials: boolean;
+    allowPrivateNetwork: boolean;
+    allowedHosts: string | string[];
+  }> = {}): CorsRequestHandler => {
+    const config = {
+      allowedOrigins: "",
+      allowedMethods: "GET,POST,PUT,DELETE,PATCH,OPTIONS",
+      allowedHeaders: "Content-Type",
+      exposedHeaders: "",
+      maxAge: 600,
+      allowCredentials: false,
+      allowPrivateNetwork: false,
+      allowedHosts: "",
+      ...overrides,
+    };
+    return new CorsRequestHandler(
+      config.allowedOrigins,
+      config.allowedMethods,
+      config.allowedHeaders,
+      config.exposedHeaders,
+      config.maxAge,
+      config.allowCredentials,
+      config.allowPrivateNetwork,
+      config.allowedHosts,
+    );
+  };
+
+  const preflightContext = (overrides: Partial<CorsRequestContextInterface> = {}): CorsRequestContextInterface => ({
+    method: "OPTIONS",
+    origin: ALLOWED_ORIGIN,
+    accessControlRequestMethod: "GET",
+    accessControlRequestPrivateNetwork: false,
+    ...overrides,
+  });
+
+  describe("activation (inactive unless configured)", () => {
+    it("is fully disabled when nothing is configured", () => {
+      const handler = makeHandler();
+
+      expect(handler.isEnabled).toBe(false);
+      expect(handler.isOriginCheckEnabled).toBe(false);
+      expect(handler.isHostCheckEnabled).toBe(false);
+      expect(handler.buildPreflightResponse(preflightContext())).toBeUndefined();
+      expect(handler.buildResponseHeaders(ALLOWED_ORIGIN)).toEqual({});
+      // No host allowlist → every host is allowed (no 403).
+      expect(handler.isHostAllowed("anything:1234")).toBe(true);
+    });
+
+    it("activates origin checking independently of host checking", () => {
+      expect(makeHandler({allowedOrigins: ALLOWED_ORIGIN}).isOriginCheckEnabled).toBe(true);
+      expect(makeHandler({allowedOrigins: ALLOWED_ORIGIN}).isHostCheckEnabled).toBe(false);
+      expect(makeHandler({allowedHosts: "127.0.0.1:6635"}).isHostCheckEnabled).toBe(true);
+      expect(makeHandler({allowedHosts: "127.0.0.1:6635"}).isOriginCheckEnabled).toBe(false);
+    });
+  });
+
+  describe("simple (non-preflight) response headers", () => {
+    it("echoes ACAO + Vary for an allow-listed origin", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      expect(handler.buildResponseHeaders(ALLOWED_ORIGIN)).toEqual({
+        "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+        "Vary": "Origin",
+      });
+    });
+
+    it("emits nothing for a non-allow-listed origin (never reflects an arbitrary Origin)", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      expect(handler.buildResponseHeaders(OTHER_ORIGIN)).toEqual({});
+    });
+
+    it("emits nothing when the request carries no Origin", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      expect(handler.buildResponseHeaders(undefined)).toEqual({});
+    });
+
+    it("never emits a wildcard even with multiple origins configured", () => {
+      const handler = makeHandler({allowedOrigins: [ALLOWED_ORIGIN, "https://second.example.com"]});
+
+      const headers = handler.buildResponseHeaders(ALLOWED_ORIGIN);
+      expect(headers["Access-Control-Allow-Origin"]).toBe(ALLOWED_ORIGIN);
+      expect(Object.values(headers)).not.toContain("*");
+    });
+
+    it("adds Access-Control-Expose-Headers only when exposed-headers is configured", () => {
+      const withExposed = makeHandler({allowedOrigins: ALLOWED_ORIGIN, exposedHeaders: "X-Total-Count, X-Page"});
+      expect(withExposed.buildResponseHeaders(ALLOWED_ORIGIN)["Access-Control-Expose-Headers"]).toBe("X-Total-Count, X-Page");
+
+      const withoutExposed = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+      expect(withoutExposed.buildResponseHeaders(ALLOWED_ORIGIN)["Access-Control-Expose-Headers"]).toBeUndefined();
+    });
+
+    it("adds Access-Control-Allow-Credentials only when enabled", () => {
+      const withCreds = makeHandler({allowedOrigins: ALLOWED_ORIGIN, allowCredentials: true});
+      expect(withCreds.buildResponseHeaders(ALLOWED_ORIGIN)["Access-Control-Allow-Credentials"]).toBe("true");
+
+      const withoutCreds = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+      expect(withoutCreds.buildResponseHeaders(ALLOWED_ORIGIN)["Access-Control-Allow-Credentials"]).toBeUndefined();
+    });
+  });
+
+  describe("preflight", () => {
+    it("answers a 204 with the full Access-Control-* set for an allow-listed origin", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      const result = handler.buildPreflightResponse(preflightContext());
+
+      expect(result).toBeDefined();
+      expect(result!.statusCode).toBe(204);
+      expect(result!.headers).toMatchObject({
+        "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+        "Vary": "Origin",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "600",
+      });
+    });
+
+    it("short-circuits a disallowed-origin preflight with a bare 204 (no ACAO headers)", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      const result = handler.buildPreflightResponse(preflightContext({origin: OTHER_ORIGIN}));
+
+      expect(result).toBeDefined();
+      expect(result!.statusCode).toBe(204);
+      expect(result!.headers).toEqual({});
+    });
+
+    it("is not a preflight when there is no Access-Control-Request-Method (plain OPTIONS routes)", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      const result = handler.buildPreflightResponse(preflightContext({accessControlRequestMethod: undefined}));
+
+      expect(result).toBeUndefined();
+    });
+
+    it("is not a preflight for a non-OPTIONS method", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      expect(handler.buildPreflightResponse(preflightContext({method: "GET"}))).toBeUndefined();
+    });
+
+    it("never takes over OPTIONS when origin checking is disabled", () => {
+      const handler = makeHandler({allowedHosts: "127.0.0.1:6635"});
+
+      expect(handler.buildPreflightResponse(preflightContext())).toBeUndefined();
+    });
+
+    it("includes Access-Control-Allow-Credentials on the preflight when enabled", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN, allowCredentials: true});
+
+      expect(handler.buildPreflightResponse(preflightContext())!.headers["Access-Control-Allow-Credentials"]).toBe("true");
+    });
+
+    it("reflects configured allowed-methods / allowed-headers / max-age", () => {
+      const handler = makeHandler({
+        allowedOrigins: ALLOWED_ORIGIN,
+        allowedMethods: "GET,POST",
+        allowedHeaders: "Content-Type,Authorization",
+        maxAge: 120,
+      });
+
+      const headers = handler.buildPreflightResponse(preflightContext())!.headers;
+      expect(headers["Access-Control-Allow-Methods"]).toBe("GET, POST");
+      expect(headers["Access-Control-Allow-Headers"]).toBe("Content-Type, Authorization");
+      expect(headers["Access-Control-Max-Age"]).toBe("120");
+    });
+  });
+
+  describe("Chrome Private Network Access", () => {
+    it("grants Access-Control-Allow-Private-Network when requested AND enabled", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN, allowPrivateNetwork: true});
+
+      const headers = handler.buildPreflightResponse(preflightContext({accessControlRequestPrivateNetwork: true}))!.headers;
+      expect(headers["Access-Control-Allow-Private-Network"]).toBe("true");
+    });
+
+    it("withholds the grant when the preflight didn't ask for it", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN, allowPrivateNetwork: true});
+
+      const headers = handler.buildPreflightResponse(preflightContext({accessControlRequestPrivateNetwork: false}))!.headers;
+      expect(headers["Access-Control-Allow-Private-Network"]).toBeUndefined();
+    });
+
+    it("withholds the grant when the operator didn't opt in, even if requested", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN, allowPrivateNetwork: false});
+
+      const headers = handler.buildPreflightResponse(preflightContext({accessControlRequestPrivateNetwork: true}))!.headers;
+      expect(headers["Access-Control-Allow-Private-Network"]).toBeUndefined();
+    });
+  });
+
+  describe("host allowlist (DNS-rebinding defense)", () => {
+    it("allows a host that exactly matches an entry", () => {
+      const handler = makeHandler({allowedHosts: "127.0.0.1:6635, localhost:6635"});
+
+      expect(handler.isHostAllowed("127.0.0.1:6635")).toBe(true);
+      expect(handler.isHostAllowed("localhost:6635")).toBe(true);
+    });
+
+    it("rejects a host that is not in the allowlist", () => {
+      const handler = makeHandler({allowedHosts: "127.0.0.1:6635"});
+
+      expect(handler.isHostAllowed("evil.example.com")).toBe(false);
+      expect(handler.isHostAllowed("127.0.0.1:9999")).toBe(false);
+    });
+
+    it("rejects a missing Host when an allowlist is configured", () => {
+      const handler = makeHandler({allowedHosts: "127.0.0.1:6635"});
+
+      expect(handler.isHostAllowed(undefined)).toBe(false);
+    });
+
+    it("matches host names case-insensitively", () => {
+      const handler = makeHandler({allowedHosts: "LocalHost:6635"});
+
+      expect(handler.isHostAllowed("localhost:6635")).toBe(true);
+    });
+  });
+
+  describe("config normalization", () => {
+    it("treats a comma-separated string and a string[] identically", () => {
+      const fromString = makeHandler({allowedOrigins: "https://a.example.com, https://b.example.com"});
+      const fromArray = makeHandler({allowedOrigins: ["https://a.example.com", "https://b.example.com"]});
+
+      expect(fromString.isOriginAllowed("https://b.example.com")).toBe(true);
+      expect(fromArray.isOriginAllowed("https://b.example.com")).toBe(true);
+    });
+
+    it("trims whitespace and drops empty entries", () => {
+      const handler = makeHandler({allowedOrigins: " https://a.example.com , , https://b.example.com "});
+
+      expect(handler.isOriginAllowed("https://a.example.com")).toBe(true);
+      expect(handler.isOriginAllowed("https://b.example.com")).toBe(true);
+      // The empty middle entry must not become a matchable "" origin.
+      expect(handler.isOriginAllowed("")).toBe(false);
+    });
+  });
+
+  describe("buildContext", () => {
+    it("normalizes raw Node headers (lower-cased, array-valued, PNA flag) into a context", () => {
+      const handler = makeHandler({allowedOrigins: ALLOWED_ORIGIN});
+
+      const context = handler.buildContext("options", {
+        "origin": ALLOWED_ORIGIN,
+        "host": "127.0.0.1:6635",
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+        "access-control-request-private-network": "true",
+        "set-cookie": ["a=1", "b=2"], // array-valued header → first element is taken
+      });
+
+      expect(context).toEqual({
+        method: "OPTIONS",
+        origin: ALLOWED_ORIGIN,
+        host: "127.0.0.1:6635",
+        accessControlRequestMethod: "GET",
+        accessControlRequestHeaders: "content-type",
+        accessControlRequestPrivateNetwork: true,
+      });
+    });
+
+    it("defaults a missing method to GET and leaves optional headers undefined", () => {
+      const handler = makeHandler();
+
+      const context = handler.buildContext(undefined as unknown as string, {});
+
+      expect(context.method).toBe("GET");
+      expect(context.origin).toBeUndefined();
+      expect(context.accessControlRequestPrivateNetwork).toBe(false);
+    });
+  });
+});

--- a/packages/http/src/cors/cors-request.handler.ts
+++ b/packages/http/src/cors/cors-request.handler.ts
@@ -1,0 +1,218 @@
+import {injectable} from "tsyringe";
+import {injectConfig, moduleScoped} from "@pristine-ts/common";
+import {HttpModuleKeyname} from "../http.module.keyname";
+import {HttpConfigurationKeys} from "../http.configuration-keys";
+import {CorsRequestContextInterface} from "./cors-request-context.interface";
+import {CorsPreflightResponseInterface} from "./cors-preflight-response.interface";
+
+/**
+ * The config-driven CORS policy engine that `KernelHttpServer` consults inside its request path,
+ * BEFORE `kernel.handle()` — the one place that sees the raw request/response and can answer a
+ * preflight or reject an origin without the networking `Router` ever running.
+ *
+ * All decision methods are pure functions of the injected configuration plus a normalized
+ * {@link CorsRequestContextInterface}, so the full behavior matrix is unit-testable by
+ * constructing this class directly (no live socket, no Node request object required).
+ *
+ * ## Activation
+ * CORS is **inactive unless configured**. Two independent switches:
+ *   - `cors.allowed-origins` non-empty  → origin/preflight/header-echo logic activates.
+ *   - `cors.allowed-hosts`   non-empty  → the Host-header allowlist (DNS-rebinding defense) activates.
+ * With neither set, every method is a no-op and the server behaves exactly as it did before CORS
+ * existed.
+ *
+ * ## Guarantees
+ *   - Never emits `Access-Control-Allow-Origin: *` — only an exact echo of an allow-listed Origin.
+ *   - Never reflects an arbitrary Origin — an Origin absent from the allowlist gets no ACAO headers.
+ */
+@moduleScoped(HttpModuleKeyname)
+@injectable()
+export class CorsRequestHandler {
+  private readonly allowedOrigins: string[];
+  private readonly allowedMethods: string[];
+  private readonly allowedHeaders: string[];
+  private readonly exposedHeaders: string[];
+  private readonly maxAge: number;
+  private readonly allowCredentials: boolean;
+  private readonly allowPrivateNetwork: boolean;
+  private readonly allowedHosts: string[];
+
+  constructor(
+    @injectConfig(HttpConfigurationKeys.CorsAllowedOrigins) allowedOrigins: string | string[],
+    @injectConfig(HttpConfigurationKeys.CorsAllowedMethods) allowedMethods: string | string[],
+    @injectConfig(HttpConfigurationKeys.CorsAllowedHeaders) allowedHeaders: string | string[],
+    @injectConfig(HttpConfigurationKeys.CorsExposedHeaders) exposedHeaders: string | string[],
+    @injectConfig(HttpConfigurationKeys.CorsMaxAge) maxAge: number,
+    @injectConfig(HttpConfigurationKeys.CorsAllowCredentials) allowCredentials: boolean,
+    @injectConfig(HttpConfigurationKeys.CorsAllowPrivateNetwork) allowPrivateNetwork: boolean,
+    @injectConfig(HttpConfigurationKeys.CorsAllowedHosts) allowedHosts: string | string[],
+  ) {
+    this.allowedOrigins = this.normalizeList(allowedOrigins);
+    this.allowedMethods = this.normalizeList(allowedMethods);
+    this.allowedHeaders = this.normalizeList(allowedHeaders);
+    this.exposedHeaders = this.normalizeList(exposedHeaders);
+    this.maxAge = maxAge;
+    this.allowCredentials = allowCredentials === true;
+    this.allowPrivateNetwork = allowPrivateNetwork === true;
+    this.allowedHosts = this.normalizeList(allowedHosts);
+  }
+
+  /**
+   * `true` when an origin allowlist is configured — gates the preflight short-circuit and the
+   * `Access-Control-Allow-Origin` echo on actual responses.
+   */
+  public get isOriginCheckEnabled(): boolean {
+    return this.allowedOrigins.length > 0;
+  }
+
+  /**
+   * `true` when a Host allowlist is configured — gates the DNS-rebinding 403.
+   */
+  public get isHostCheckEnabled(): boolean {
+    return this.allowedHosts.length > 0;
+  }
+
+  /**
+   * Whether any CORS feature is active. `KernelHttpServer` can skip all CORS work when this is
+   * `false`, keeping the un-configured request path byte-for-byte identical to before.
+   */
+  public get isEnabled(): boolean {
+    return this.isOriginCheckEnabled || this.isHostCheckEnabled;
+  }
+
+  /**
+   * Normalizes a raw Node request into the transport-agnostic {@link CorsRequestContextInterface}.
+   * Node lower-cases header names on `IncomingMessage`, and multi-valued headers arrive as arrays;
+   * we take the method + the CORS-relevant headers and coerce them to the single-string shape the
+   * decision methods expect.
+   */
+  public buildContext(method: string, headers: { [key: string]: string | string[] | undefined }): CorsRequestContextInterface {
+    const readHeader = (name: string): string | undefined => {
+      const value = headers[name];
+      if (Array.isArray(value)) {
+        return value[0];
+      }
+      return value ?? undefined;
+    };
+
+    return {
+      method: (method ?? "GET").toUpperCase(),
+      origin: readHeader("origin"),
+      host: readHeader("host"),
+      accessControlRequestMethod: readHeader("access-control-request-method"),
+      accessControlRequestHeaders: readHeader("access-control-request-headers"),
+      accessControlRequestPrivateNetwork: (readHeader("access-control-request-private-network") ?? "").toLowerCase() === "true",
+    };
+  }
+
+  /**
+   * Host-header allowlist check (loopback DNS-rebinding defense). Returns `true` (allow) when no
+   * allowlist is configured; otherwise the request's `Host` must exactly match a configured entry
+   * (case-insensitive, since host names are). A missing `Host` against a configured allowlist is
+   * rejected. `KernelHttpServer` turns a `false` here into a `403` before any routing.
+   */
+  public isHostAllowed(host: string | undefined): boolean {
+    if (this.isHostCheckEnabled === false) {
+      return true;
+    }
+    if (host === undefined) {
+      return false;
+    }
+    const normalizedHost = host.trim().toLowerCase();
+    return this.allowedHosts.some(allowedHost => allowedHost.toLowerCase() === normalizedHost);
+  }
+
+  /**
+   * Exact-match origin allowlist check. An absent Origin is never "allowed" (there is nothing to
+   * echo). We never wildcard and never reflect an arbitrary Origin.
+   */
+  public isOriginAllowed(origin: string | undefined): boolean {
+    if (origin === undefined) {
+      return false;
+    }
+    const normalizedOrigin = origin.trim();
+    return this.allowedOrigins.some(allowedOrigin => allowedOrigin === normalizedOrigin);
+  }
+
+  /**
+   * Decides whether `context` is a CORS preflight that must be answered before routing, and if so
+   * returns the `204` response (status + headers) to write. Returns `undefined` when the request is
+   * not a preflight we own — the caller then lets it route normally.
+   *
+   * A CORS preflight is an `OPTIONS` carrying `Access-Control-Request-Method`. We only take over
+   * preflight handling when an origin allowlist is configured (same-origin requests never send
+   * `Access-Control-Request-Method`, so app-owned `OPTIONS` routes are never stolen). An allow-listed
+   * Origin gets the full `Access-Control-*` set; a disallowed Origin still gets a bare `204` with no
+   * ACAO — the browser blocks it, and we never leak an arbitrary Origin.
+   */
+  public buildPreflightResponse(context: CorsRequestContextInterface): CorsPreflightResponseInterface | undefined {
+    if (this.isOriginCheckEnabled === false) {
+      return undefined;
+    }
+    if (context.method !== "OPTIONS" || context.accessControlRequestMethod === undefined) {
+      return undefined;
+    }
+
+    const headers: { [name: string]: string } = {};
+
+    if (this.isOriginAllowed(context.origin)) {
+      headers["Access-Control-Allow-Origin"] = context.origin as string;
+      headers["Vary"] = "Origin";
+      headers["Access-Control-Allow-Methods"] = this.allowedMethods.join(", ");
+      headers["Access-Control-Allow-Headers"] = this.allowedHeaders.join(", ");
+      headers["Access-Control-Max-Age"] = String(this.maxAge);
+
+      if (this.allowCredentials) {
+        headers["Access-Control-Allow-Credentials"] = "true";
+      }
+
+      // Chrome Private Network Access: only answer the grant when the preflight actually asked for
+      // it AND the operator opted in. Silence otherwise so we never advertise a capability we
+      // weren't configured to allow.
+      if (this.allowPrivateNetwork && context.accessControlRequestPrivateNetwork) {
+        headers["Access-Control-Allow-Private-Network"] = "true";
+      }
+    }
+
+    return {statusCode: 204, headers};
+  }
+
+  /**
+   * The CORS headers to add to an ACTUAL (non-preflight) response — success OR error. Returns an
+   * empty object when origin-checking is off or the Origin is not allow-listed. Applied to 4xx/5xx
+   * responses too: without `Access-Control-Allow-Origin` the browser cannot read an error body.
+   */
+  public buildResponseHeaders(origin: string | undefined): { [name: string]: string } {
+    if (this.isOriginCheckEnabled === false || this.isOriginAllowed(origin) === false) {
+      return {};
+    }
+
+    const headers: { [name: string]: string } = {
+      "Access-Control-Allow-Origin": origin as string,
+      "Vary": "Origin",
+    };
+
+    if (this.allowCredentials) {
+      headers["Access-Control-Allow-Credentials"] = "true";
+    }
+
+    if (this.exposedHeaders.length > 0) {
+      headers["Access-Control-Expose-Headers"] = this.exposedHeaders.join(", ");
+    }
+
+    return headers;
+  }
+
+  /**
+   * Coerces a list-shaped config value into a trimmed, empty-stripped `string[]`. Accepts both the
+   * comma-separated string form (env vars / defaults) and the `string[]` form (programmatic
+   * `kernel.start()` config).
+   */
+  private normalizeList(value: string | string[] | undefined | null): string[] {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    const parts = Array.isArray(value) ? value : String(value).split(",");
+    return parts.map(part => part.trim()).filter(part => part.length > 0);
+  }
+}

--- a/packages/http/src/cors/cors.ts
+++ b/packages/http/src/cors/cors.ts
@@ -1,0 +1,3 @@
+export * from "./cors-preflight-response.interface";
+export * from "./cors-request-context.interface";
+export * from "./cors-request.handler";

--- a/packages/http/src/http.configuration-keys.ts
+++ b/packages/http/src/http.configuration-keys.ts
@@ -17,6 +17,21 @@ export const HttpConfigurationKeys = {
   KernelServerPort: "pristine.http.kernel-server.port",
   KernelServerTlsKeyPath: "pristine.http.kernel-server.tls.key-path",
   KernelServerTlsCertPath: "pristine.http.kernel-server.tls.cert-path",
+
+  /**
+   * CORS keys consumed by `CorsRequestHandler` inside `KernelHttpServer`'s request path.
+   * CORS is inactive unless `cors.allowed-origins` (and/or `cors.allowed-hosts`) is set —
+   * a server with none of these configured behaves exactly as it did before CORS existed.
+   * Each list key accepts a comma-separated string or a `string[]`.
+   */
+  CorsAllowedOrigins: "pristine.http.cors.allowed-origins",
+  CorsAllowedMethods: "pristine.http.cors.allowed-methods",
+  CorsAllowedHeaders: "pristine.http.cors.allowed-headers",
+  CorsExposedHeaders: "pristine.http.cors.exposed-headers",
+  CorsMaxAge: "pristine.http.cors.max-age",
+  CorsAllowCredentials: "pristine.http.cors.allow-credentials",
+  CorsAllowPrivateNetwork: "pristine.http.cors.allow-private-network",
+  CorsAllowedHosts: "pristine.http.cors.allowed-hosts",
 } as const;
 
 /**
@@ -31,6 +46,17 @@ export interface HttpConfigurationValueMap {
   "pristine.http.kernel-server.port": number;
   "pristine.http.kernel-server.tls.key-path": string;
   "pristine.http.kernel-server.tls.cert-path": string;
+  // List keys resolve to a comma-separated string from env/defaults; a consumer may also pass
+  // a `string[]` programmatically via `kernel.start()` config. `CorsRequestHandler` normalizes
+  // both forms, so the map documents the canonical (string) shape.
+  "pristine.http.cors.allowed-origins": string;
+  "pristine.http.cors.allowed-methods": string;
+  "pristine.http.cors.allowed-headers": string;
+  "pristine.http.cors.exposed-headers": string;
+  "pristine.http.cors.max-age": number;
+  "pristine.http.cors.allow-credentials": boolean;
+  "pristine.http.cors.allow-private-network": boolean;
+  "pristine.http.cors.allowed-hosts": string;
 }
 
 

--- a/packages/http/src/http.module.ts
+++ b/packages/http/src/http.module.ts
@@ -11,6 +11,7 @@ import {KernelHttpServer} from "./servers/kernel.http-server";
 export * from "./http.module.keyname";
 export * from "./commands/commands";
 export * from "./clients/clients";
+export * from "./cors/cors";
 export * from "./enums/enums";
 export * from "./errors/errors";
 export * from "./interceptors/interceptors"
@@ -102,6 +103,106 @@ export const HttpModule: ModuleInterface = {
       isRequired: false,
       defaultResolvers: [
         new EnvironmentVariableResolver("PRISTINE_HTTP_KERNEL_SERVER_TLS_CERT_PATH"),
+      ]
+    },
+    /**
+     * CORS — handled by `CorsRequestHandler` inside `KernelHttpServer`'s request path. All keys
+     * carry defaults so `@injectConfig` always resolves; CORS stays INACTIVE until
+     * `cors.allowed-origins` (and/or `cors.allowed-hosts`) is set. List keys accept a
+     * comma-separated string (env/default) or a `string[]` (programmatic config).
+     *
+     * Exact-match origin allowlist. Empty (the default) = CORS disabled: no preflight
+     * short-circuit and no `Access-Control-Allow-Origin` echo. Never wildcarded.
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.allowed-origins`,
+      defaultValue: "",
+      isRequired: false,
+      defaultResolvers: [
+        new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_ALLOWED_ORIGINS"),
+      ]
+    },
+    /**
+     * Methods advertised in the preflight `Access-Control-Allow-Methods` response.
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.allowed-methods`,
+      defaultValue: "GET,POST,PUT,DELETE,PATCH,OPTIONS",
+      isRequired: false,
+      defaultResolvers: [
+        new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_ALLOWED_METHODS"),
+      ]
+    },
+    /**
+     * Request headers advertised in the preflight `Access-Control-Allow-Headers` response.
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.allowed-headers`,
+      defaultValue: "Content-Type",
+      isRequired: false,
+      defaultResolvers: [
+        new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_ALLOWED_HEADERS"),
+      ]
+    },
+    /**
+     * Response headers exposed to the browser via `Access-Control-Expose-Headers` on actual
+     * responses. Empty (the default) omits the header entirely.
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.exposed-headers`,
+      defaultValue: "",
+      isRequired: false,
+      defaultResolvers: [
+        new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_EXPOSED_HEADERS"),
+      ]
+    },
+    /**
+     * Seconds a browser may cache the preflight result (`Access-Control-Max-Age`).
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.max-age`,
+      defaultValue: 600,
+      isRequired: false,
+      defaultResolvers: [
+        new NumberResolver(new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_MAX_AGE")),
+      ]
+    },
+    /**
+     * When true, emit `Access-Control-Allow-Credentials: true` on preflight and actual responses
+     * for allow-listed origins (lets the browser send cookies / `Authorization`).
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.allow-credentials`,
+      defaultValue: false,
+      isRequired: false,
+      defaultResolvers: [
+        new BooleanResolver(new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_ALLOW_CREDENTIALS")),
+      ]
+    },
+    /**
+     * Chrome Private Network Access. When true, answer `Access-Control-Allow-Private-Network: true`
+     * to a preflight that carries `Access-Control-Request-Private-Network: true` — required for a
+     * public/secure site to call a loopback/private-network daemon.
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.allow-private-network`,
+      defaultValue: false,
+      isRequired: false,
+      defaultResolvers: [
+        new BooleanResolver(new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_ALLOW_PRIVATE_NETWORK")),
+      ]
+    },
+    /**
+     * Optional `Host`-header allowlist (loopback DNS-rebinding defense). When set, a request whose
+     * `Host` is not listed is rejected with `403` before routing. Empty (the default) disables the
+     * check. Independent of `allowed-origins`.
+     */
+    {
+      parameterName: `${HttpModuleKeyname}.cors.allowed-hosts`,
+      defaultValue: "",
+      isRequired: false,
+      defaultResolvers: [
+        new EnvironmentVariableResolver("PRISTINE_HTTP_CORS_ALLOWED_HOSTS"),
       ]
     },
   ],

--- a/packages/http/src/servers/kernel.http-server.cors.spec.ts
+++ b/packages/http/src/servers/kernel.http-server.cors.spec.ts
@@ -1,0 +1,242 @@
+import "reflect-metadata";
+import {injectable} from "tsyringe";
+import {Kernel} from "@pristine-ts/core";
+import {AppModuleInterface, HttpMethod} from "@pristine-ts/common";
+import {controller, route} from "@pristine-ts/networking";
+import {HttpModule} from "../http.module";
+import {HttpConfigurationKeys} from "../http.configuration-keys";
+import {CorsRequestHandler} from "../cors/cors-request.handler";
+import {KernelHttpServer} from "./kernel.http-server";
+
+/**
+ * End-to-end CORS coverage against a REAL `KernelHttpServer` bound to `127.0.0.1:0` (ephemeral
+ * port), driven with real `fetch` over an actual socket. Proves the wiring the pure
+ * `CorsRequestHandler` unit tests can't: that `KernelHttpServer.handleRequest` short-circuits a
+ * preflight before routing and echoes `Access-Control-Allow-Origin` on real responses.
+ *
+ * `@pristine-ts/networking` is already in `HttpModule`'s graph (`ValidationModule` imports
+ * `NetworkingModule`), so its `Router` routes to the controller below — declared with the real
+ * `@controller`/`@route` decorators and discovered from networking's global controller registry.
+ */
+
+const ALLOWED_ORIGIN = "https://app.example.com";
+
+@controller("/widgets")
+@injectable()
+class WidgetsTestController {
+  @route(HttpMethod.Get, "")
+  async list(): Promise<object> {
+    return {ok: true, path: "/widgets"};
+  }
+
+  @route(HttpMethod.Get, "/boom")
+  async boom(): Promise<object> {
+    throw new Error("intentional failure to exercise the error path");
+  }
+}
+
+// Reference the class so its `@controller`/`@route` side effects run even under aggressive tree-shaking.
+void WidgetsTestController;
+
+interface LiveServer {
+  server: KernelHttpServer;
+  baseUrl: string;
+}
+
+const appModule = (): AppModuleInterface => ({
+  keyname: "test.http-cors-app",
+  importModules: [HttpModule],
+  importServices: [],
+});
+
+/**
+ * Boots a kernel with `HttpModule` + the given CORS config, then starts a `KernelHttpServer` on an
+ * ephemeral loopback port. Mirrors what the CLI's `bootstrap()` does — notably
+ * `registerInstance(Kernel, kernel)` so `KernelHttpServer`'s injected `kernel` is the running one.
+ */
+async function bootServer(corsConfig: { [key: string]: unknown }): Promise<LiveServer> {
+  const kernel = new Kernel();
+  await kernel.start(appModule(), {
+    "pristine.logging.consoleLoggerActivated": false,
+    ...corsConfig,
+  });
+  kernel.container.registerInstance(Kernel, kernel);
+
+  const server = kernel.container.resolve(KernelHttpServer);
+  await server.start({port: 0, address: "127.0.0.1"});
+
+  const address = server.getAddress();
+  if (address === null || typeof address === "string") {
+    throw new Error("KernelHttpServer did not bind to a TCP address");
+  }
+
+  return {server, baseUrl: `http://127.0.0.1:${address.port}`};
+}
+
+describe("KernelHttpServer CORS (live socket)", () => {
+  describe("with an origin allowlist (+ Private Network Access enabled)", () => {
+    let live: LiveServer;
+
+    beforeAll(async () => {
+      live = await bootServer({
+        [HttpConfigurationKeys.CorsAllowedOrigins]: ALLOWED_ORIGIN,
+        [HttpConfigurationKeys.CorsAllowedHeaders]: "Content-Type,Authorization",
+        [HttpConfigurationKeys.CorsAllowPrivateNetwork]: true,
+      });
+    });
+
+    afterAll(async () => {
+      await live?.server.stop();
+    });
+
+    it("answers a preflight with 204 + echoed ACAO, allowed methods, max-age, and the PNA grant", async () => {
+      const response = await fetch(`${live.baseUrl}/widgets`, {
+        method: "OPTIONS",
+        headers: {
+          "Origin": ALLOWED_ORIGIN,
+          "Access-Control-Request-Method": "GET",
+          "Access-Control-Request-Private-Network": "true",
+        },
+      });
+      // Drain the (empty) body so the socket can be reused / closed cleanly.
+      await response.text();
+
+      expect(response.status).toBe(204);
+      expect(response.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
+      expect(response.headers.get("vary")).toContain("Origin");
+      expect(response.headers.get("access-control-allow-methods")).toContain("GET");
+      expect(response.headers.get("access-control-allow-headers")).toContain("Authorization");
+      expect(response.headers.get("access-control-max-age")).toBe("600");
+      expect(response.headers.get("access-control-allow-private-network")).toBe("true");
+    });
+
+    it("echoes ACAO + Vary on an actual (routed 200) GET", async () => {
+      const response = await fetch(`${live.baseUrl}/widgets`, {
+        method: "GET",
+        headers: {"Origin": ALLOWED_ORIGIN},
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
+      expect(response.headers.get("vary")).toContain("Origin");
+      expect(body).toEqual({ok: true, path: "/widgets"});
+    });
+
+    it("still echoes ACAO on an error (500) response so the browser can read the body", async () => {
+      const response = await fetch(`${live.baseUrl}/widgets/boom`, {
+        method: "GET",
+        headers: {"Origin": ALLOWED_ORIGIN},
+      });
+      await response.text();
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
+      expect(response.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
+    });
+
+    it("emits no ACAO for a non-allow-listed origin", async () => {
+      const response = await fetch(`${live.baseUrl}/widgets`, {
+        method: "GET",
+        headers: {"Origin": "https://evil.example.com"},
+      });
+      await response.text();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    });
+  });
+
+  describe("with a Host allowlist", () => {
+    let live: LiveServer;
+
+    beforeAll(async () => {
+      // The allowlist deliberately excludes the ephemeral `127.0.0.1:<port>` Host that fetch will
+      // send, so every request should be rejected before routing.
+      live = await bootServer({
+        [HttpConfigurationKeys.CorsAllowedHosts]: "daemon.local:6635",
+      });
+    });
+
+    afterAll(async () => {
+      await live?.server.stop();
+    });
+
+    it("rejects a request whose Host is not allow-listed with a 403 before routing", async () => {
+      const response = await fetch(`${live.baseUrl}/widgets`, {method: "GET"});
+      await response.text();
+
+      expect(response.status).toBe(403);
+    });
+  });
+});
+
+/**
+ * Deterministic unit coverage for the one behavior a live-socket test can't force reliably: the
+ * CORS headers being applied on `handleRequest`'s catch/500 path (kernel.handle rejecting), not
+ * only the success path. Drives the private method with a stub kernel that throws and a fake
+ * `ServerResponse` that records what got written.
+ */
+describe("KernelHttpServer CORS error path", () => {
+  const buildFakeResponse = () => {
+    const headers: { [name: string]: string } = {};
+    return {
+      headersSent: false,
+      statusCode: 0,
+      setHeader(name: string, value: string) {
+        headers[name.toLowerCase()] = value;
+      },
+      end(_body?: unknown) {
+        (this as any).ended = true;
+      },
+      ended: false,
+      capturedHeaders: headers,
+    };
+  };
+
+  it("echoes Access-Control-Allow-Origin on the 500 when kernel.handle throws", async () => {
+    const corsRequestHandler = new CorsRequestHandler(ALLOWED_ORIGIN, "GET,POST", "Content-Type", "", 600, false, false, "");
+    const logHandler = {error: jest.fn(), warning: jest.fn(), info: jest.fn(), debug: jest.fn()} as any;
+    const kernel = {handle: jest.fn().mockRejectedValue(new Error("boom"))} as any;
+    const eventIdManager = {generateEventId: () => "req-1"} as any;
+
+    const server = new KernelHttpServer("127.0.0.1", 0, "", "", logHandler, kernel, eventIdManager, corsRequestHandler);
+
+    const req = {
+      method: "GET",
+      url: "/widgets",
+      headers: {origin: ALLOWED_ORIGIN, host: "127.0.0.1:6635"},
+      socket: {},
+    } as any;
+    const res = buildFakeResponse();
+
+    await (server as any).handleRequest(req, res as any);
+
+    expect(kernel.handle).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(500);
+    expect(res.capturedHeaders["access-control-allow-origin"]).toBe(ALLOWED_ORIGIN);
+    expect(res.capturedHeaders["vary"]).toBe("Origin");
+    expect(res.ended).toBe(true);
+  });
+
+  it("omits Access-Control-Allow-Origin on the 500 for a non-allow-listed origin", async () => {
+    const corsRequestHandler = new CorsRequestHandler(ALLOWED_ORIGIN, "GET,POST", "Content-Type", "", 600, false, false, "");
+    const logHandler = {error: jest.fn(), warning: jest.fn(), info: jest.fn(), debug: jest.fn()} as any;
+    const kernel = {handle: jest.fn().mockRejectedValue(new Error("boom"))} as any;
+    const eventIdManager = {generateEventId: () => "req-2"} as any;
+
+    const server = new KernelHttpServer("127.0.0.1", 0, "", "", logHandler, kernel, eventIdManager, corsRequestHandler);
+
+    const req = {
+      method: "GET",
+      url: "/widgets",
+      headers: {origin: "https://evil.example.com", host: "127.0.0.1:6635"},
+      socket: {},
+    } as any;
+    const res = buildFakeResponse();
+
+    await (server as any).handleRequest(req, res as any);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.capturedHeaders["access-control-allow-origin"]).toBeUndefined();
+  });
+});

--- a/packages/http/src/servers/kernel.http-server.ts
+++ b/packages/http/src/servers/kernel.http-server.ts
@@ -7,6 +7,7 @@ import {EventIdManager, ExecutionContextKeynameEnum, Kernel, RuntimeServerInterf
 import {moduleScoped, Request, Response, ServiceDefinitionTagEnum, tag} from "@pristine-ts/common";
 import {LogHandlerInterface} from "@pristine-ts/logging";
 import {HttpModuleKeyname} from "../http.module.keyname";
+import {CorsRequestHandler} from "../cors/cors-request.handler";
 
 /**
  * Per-request override of the start-time bound port/address pair. Both are optional — when
@@ -70,6 +71,7 @@ export class KernelHttpServer implements RuntimeServerInterface {
     @inject("LogHandlerInterface") private readonly logHandler: LogHandlerInterface,
     private readonly kernel: Kernel,
     private readonly eventIdManager: EventIdManager,
+    private readonly corsRequestHandler: CorsRequestHandler,
   ) {
   }
 
@@ -169,6 +171,15 @@ export class KernelHttpServer implements RuntimeServerInterface {
   }
 
   /**
+   * The address the underlying server is bound to, or `null` when not listening. For a TCP socket
+   * this is `{address, family, port}` — useful when binding to port `0` (ephemeral port) and the
+   * caller needs to discover the assigned port afterwards.
+   */
+  public getAddress(): import("net").AddressInfo | string | null {
+    return this.server?.address() ?? null;
+  }
+
+  /**
    * Reads the body, builds a Pristine `Request`, dispatches via the kernel, writes the
    * resulting `Response`. All errors are caught and turned into a 500 response so the
    * caller's request always gets an answer.
@@ -177,14 +188,45 @@ export class KernelHttpServer implements RuntimeServerInterface {
   private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const requestId = (req.headers["x-pristine-request-id"] as string | undefined) ?? this.eventIdManager.generateEventId();
 
+    // Normalize the raw request into the CORS decision context up-front. When no CORS config is
+    // present every method below is a no-op, so this whole block is transparent to un-configured
+    // servers. `corsResponseHeaders` (ACAO + Vary + ...) is computed once here and applied to
+    // BOTH the success and the error/500 responses below — a browser can only read an error body
+    // if the error response also carries Access-Control-Allow-Origin.
+    const corsContext = this.corsRequestHandler.buildContext(req.method ?? "GET", req.headers);
+    const corsResponseHeaders = this.corsRequestHandler.buildResponseHeaders(corsContext.origin);
+
     try {
+      // 1. Host-header allowlist (loopback DNS-rebinding defense) — reject before routing and
+      // before reading the body, so a rejected caller can't stream a payload at us.
+      if (this.corsRequestHandler.isHostAllowed(corsContext.host) === false) {
+        this.logHandler.warning("KernelHttpServer: rejecting request with disallowed Host header", {
+          extra: {host: corsContext.host, url: req.url, method: req.method, requestId},
+        });
+        res.statusCode = 403;
+        this.applyHeaders(res, corsResponseHeaders);
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({error: "Forbidden", requestId}));
+        return;
+      }
+
+      // 2. CORS preflight — answered with a 204 and short-circuited BEFORE kernel.handle, since a
+      // preflight never matches a real route in the networking Router.
+      const preflight = this.corsRequestHandler.buildPreflightResponse(corsContext);
+      if (preflight !== undefined) {
+        res.statusCode = preflight.statusCode;
+        this.applyHeaders(res, preflight.headers);
+        res.end();
+        return;
+      }
+
       const request = await this.mapToPristineRequest(req, requestId);
       const result = await this.kernel.handle(request, {
         keyname: ExecutionContextKeynameEnum.Http,
         context: null,
       }) as Response | object;
 
-      this.writeResponse(res, result);
+      this.writeResponse(res, result, corsResponseHeaders);
     } catch (error) {
       this.logHandler.error("KernelHttpServer: unhandled error while processing request", {
         extra: {error, url: req.url, method: req.method, requestId},
@@ -193,6 +235,9 @@ export class KernelHttpServer implements RuntimeServerInterface {
       // can only destroy the socket — but most kernel.handle errors propagate before any write.
       if (res.headersSent === false) {
         res.statusCode = 500;
+        // Echo CORS headers on the error path too — otherwise the browser blocks the response and
+        // the caller never sees the 500 body.
+        this.applyHeaders(res, corsResponseHeaders);
         res.setHeader("content-type", "application/json");
         res.end(JSON.stringify({error: "Internal Server Error", requestId}));
       } else {
@@ -274,9 +319,13 @@ export class KernelHttpServer implements RuntimeServerInterface {
    * Writes a Pristine `Response` (or any object — handlers that return raw JSON serialize as-is)
    * back to the underlying `ServerResponse`. Default status is 200, default content-type is
    * `application/json` when the body is non-string.
+   *
+   * `corsHeaders` (empty when CORS is off or the Origin isn't allow-listed) is applied AFTER the
+   * response's own headers so the `Access-Control-*` set is authoritative and a handler can't
+   * accidentally clobber it.
    * @private
    */
-  private writeResponse(res: ServerResponse, result: Response | any): void {
+  private writeResponse(res: ServerResponse, result: Response | any, corsHeaders: { [k: string]: string } = {}): void {
     const isPristineResponse = result instanceof Response || (
       result !== null && typeof result === "object" && typeof (result as any).status === "number" && "body" in result
     );
@@ -296,6 +345,7 @@ export class KernelHttpServer implements RuntimeServerInterface {
       // Buffer body: write directly without re-encoding. Don't auto-set content-type — the
       // handler that produced a Buffer is presumed to know what it's sending.
       this.applyHeaders(res, headers);
+      this.applyHeaders(res, corsHeaders);
       res.end(body);
       return;
     } else {
@@ -306,6 +356,7 @@ export class KernelHttpServer implements RuntimeServerInterface {
     }
 
     this.applyHeaders(res, headers);
+    this.applyHeaders(res, corsHeaders);
     res.end(serializedBody);
   }
 


### PR DESCRIPTION
## Summary

Adds browser-facing **CORS** to `@pristine-ts/http`, driven entirely from configuration — no adapter or middleware. A new `CorsRequestHandler` collaborator is consulted inside `KernelHttpServer.handleRequest`, **before `kernel.handle()`** (the one place that sees the raw req/res and can answer without the networking `Router`), so it can:

- short-circuit an `OPTIONS` preflight → `204` **before routing**, and
- reject a bad `Host` → `403` **before routing** (loopback DNS-rebinding defense).

**CORS is inactive unless configured** — a server with no `cors.*` config behaves exactly as before.

## Config keys (`pristine.http.cors.*`, env `PRISTINE_HTTP_CORS_*`)

| Key | Default | Purpose |
|---|---|---|
| `allowed-origins` | `""` (disabled) | exact-match allowlist (comma string **or** `string[]`) |
| `allowed-methods` | `GET,POST,PUT,DELETE,PATCH,OPTIONS` | preflight `Allow-Methods` |
| `allowed-headers` | `Content-Type` | preflight `Allow-Headers` |
| `exposed-headers` | `""` | `Expose-Headers` on actual responses |
| `max-age` | `600` | preflight cache seconds |
| `allow-credentials` | `false` | `Allow-Credentials: true` |
| `allow-private-network` | `false` | Chrome Private Network Access grant |
| `allowed-hosts` | `""` | `Host` allowlist → `403` before routing |

## Behavior

- `OPTIONS` carrying `Access-Control-Request-Method` from an allow-listed `Origin` → `204`, short-circuited before routing, with echoed ACAO, `Vary: Origin`, methods/headers/max-age (+ `Access-Control-Allow-Private-Network: true` when the preflight requests it **and** `allow-private-network` is on).
- Non-allow-listed `Origin` → **no** ACAO emitted. Never `*`, never a reflected arbitrary origin.
- Non-preflight requests from an allow-listed `Origin` → ACAO + `Vary: Origin` on the response, **including error (4xx/5xx) responses** (applied on the catch/500 path, not just success) so the browser can read error bodies.
- `allowed-hosts` configured and `Host` not matching → `403` before routing.

## Enabling it

```ts
await kernel.start(AppModule, {
  "pristine.http.cors.allowed-origins": "https://app.example.com",
  "pristine.http.cors.allow-private-network": true,
  "pristine.http.cors.allowed-hosts": "127.0.0.1:6635,localhost:6635",
});
```

## Design notes

- One dedicated, injectable collaborator (`CorsRequestHandler`) holds the pure decision logic; `KernelHttpServer` only extracts a normalized context and applies the results — so the full matrix is unit-testable with no socket.
- One deliberate simplification: on an actual response `Vary: Origin` is set authoritatively (replaces rather than merges with any `Vary` a handler already set) — standard for CORS at this layer.

## Tests — `42 passed` (was 9), `tsc` build + eslint clean

- `cors/cors-request.handler.spec.ts` (26): allowed/disallowed/absent origin, preflight vs simple, PNA requested×enabled (all combos), host hit/miss/missing/case-insensitive, credentials on/off, exposed-headers, comma-vs-array normalization, context extraction.
- `servers/kernel.http-server.cors.spec.ts` (7): **live server on `127.0.0.1:0` + real `fetch`** — `204` preflight with echoed ACAO/methods/max-age/PNA, ACAO+`Vary` on a routed `200` GET, ACAO on a `500`, no ACAO for a foreign origin, `403` on a bad Host; plus two deterministic catch-path unit tests (throwing kernel) for the `500` echo.

## Follow-up (not in this PR)

A consumer's manual wildcard-CORS block (e.g. an Express-adapter middleware) can be dropped in favor of this config **only if that server runs via `KernelHttpServer`** (`pristine start`) — this CORS lives in `KernelHttpServer.handleRequest`, not the `@pristine-ts/express` adapter path.

Ships in **`@pristine-ts/http@4.0.3`** (next `lerna version patch` on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRrrAN52snKdkDbpwB19wG