### PR TITLE
feat(auth0): configurable module-level expected audience

### DIFF
--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — @pristine-ts/auth0
+
+## 4.0.3
+
+- **Centrally configurable expected audience.** The audience (`aud` claim) an Auth0 access token must contain can now
+  be configured once at the module level via the `pristine.auth0.expected.audience` configuration key (environment
+  variable `PRISTINE_AUTH0_EXPECTED_AUDIENCE`), instead of having to be passed as an
+  `@authenticator(Auth0Authenticator, {expectedAudience})` option on every controller. This makes it practical to
+  enforce audience validation everywhere (per RFC 9068 a resource server should validate `aud`) rather than relying on
+  each route opting in.
+
+  Resolution precedence: a per-decorator `expectedAudience` option wins; otherwise the configured audience is used; if
+  neither is set the `aud` claim is not validated. The feature is **opt-in and fully backward compatible** — with no
+  option and no configuration the behavior is exactly as before (no audience check). The new configuration key is
+  **not** required: it resolves to the empty-string "unset" sentinel when absent, so adding the module never breaks
+  boot and no default audience is invented.
+
+- **`expectedAudience` now also accepts an array.** In addition to a single `string`, the decorator option accepts
+  `string[]`; the check then passes when the token's `aud` intersects the expected set. The single-string path is
+  unchanged.
+
+- **Exact audience matching (latent bug fix).** Audience membership is now an exact match. The previous code used
+  `claim.aud.includes(expectedAudience)`, which — when a token's `aud` is a single string rather than an array —
+  performed a *substring* match (e.g. `"pristine-ts.com"` would match a token audience of `"https://pristine-ts.com"`).
+  Both a string and an array `aud` are now normalized to a list before an exact-membership check.
+
+- Added a typed `Auth0AuthenticatorOptionsInterface` for the `@authenticator` options (`expectedAudience` /
+  `expectedScopes`, previously untyped `any`) and an `Auth0ConfigurationKeys` constant + `Auth0ConfigurationValueMap`
+  for the package's configuration keys (mirroring `@pristine-ts/jwt`).

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -25,5 +25,10 @@
   Both a string and an array `aud` are now normalized to a list before an exact-membership check.
 
 - Added a typed `Auth0AuthenticatorOptionsInterface` for the `@authenticator` options (`expectedAudience` /
-  `expectedScopes`, previously untyped `any`) and an `Auth0ConfigurationKeys` constant + `Auth0ConfigurationValueMap`
-  for the package's configuration keys (mirroring `@pristine-ts/jwt`).
+  `expectedScopes`, previously untyped `any`) and an `Auth0ConfigurationKeys` constant for the package's
+  configuration keys.
+
+- **`@authenticator(Auth0Authenticator, …)` options are now type-checked.** `Auth0Authenticator` declares a phantom
+  `static __options` marker that the (now generic) `@authenticator` decorator infers, so a mistyped or wrong-typed
+  option — e.g. `expectedScope` instead of `expectedScopes`, or a non-string audience — is a compile error at the
+  call site. Requires `@pristine-ts/security` >= 4.0.3; authenticators without the marker are unaffected.

--- a/packages/auth0/readme.md
+++ b/packages/auth0/readme.md
@@ -25,13 +25,61 @@ export const AppModule: AppModuleInterface = {
 
 ### 2- Put in the configuration the value for your Auth0 domain
 
-By default, you can define the environment variable: `PRISTINE_AUTH0_ISSSUER_DOMAIN`
+By default, you can define the environment variable: `PRISTINE_AUTH0_ISSUER_DOMAIN`
+
+(This maps to the configuration key `pristine.auth0.issuer.domain`.)
 
 That's it, if you make an HTTP Request to a Pristine microservice and you pass a valid JWT as a HTTP Header:
 
 ```
 Authorization: Bearer YOUR_JWT_HERE
 ```
+
+### 3- (Optional) Validate the token audience
+
+Per [RFC 9068](https://www.rfc-editor.org/rfc/rfc9068), a resource server should validate that an access token's
+`aud` (audience) claim is intended for it. You can enable this check **centrally**, so it no longer has to be passed
+as an option on every controller:
+
+| Configuration key                  | Environment variable               | Required |
+|------------------------------------|------------------------------------|----------|
+| `pristine.auth0.expected.audience` | `PRISTINE_AUTH0_EXPECTED_AUDIENCE` | No       |
+
+```ts
+// e.g. via kernel.start(), pristine.config.ts, or the environment variable above:
+await kernel.start(AppModule, {
+    "pristine.auth0.expected.audience": "https://api.my-service.com",
+});
+```
+
+When set, every request authenticated with the `Auth0Authenticator` must present a token whose `aud` claim contains
+that audience. Matching is **exact**: a single-string `aud` must equal the expected value (no substring match), and an
+array `aud` must contain it.
+
+**This is opt-in and 100% backward compatible.** If neither the configuration nor a decorator option is set, the
+audience is **not** validated (the previous behavior). The configuration key is optional and resolves to an "unset"
+sentinel when absent, so leaving it out never breaks startup.
+
+#### Per-controller override
+
+You can still set (or override) the expected audience per route via the `@authenticator` decorator. A decorator option
+always **wins** over the module-level configuration:
+
+```ts
+@authenticator(Auth0Authenticator, {expectedAudience: "https://api.my-service.com"})
+export class MyController {
+    // ...
+}
+```
+
+`expectedAudience` accepts either a single audience (`string`) or several (`string[]`); with an array, the check passes
+when the token's `aud` intersects the expected set.
+
+**Resolution precedence** (first match wins):
+
+1. The `@authenticator(Auth0Authenticator, {expectedAudience})` decorator option, when present.
+2. The `pristine.auth0.expected.audience` configuration, otherwise.
+3. If neither is set, the audience check is skipped.
 
 ### Example
 

--- a/packages/auth0/readme.md
+++ b/packages/auth0/readme.md
@@ -75,6 +75,9 @@ export class MyController {
 `expectedAudience` accepts either a single audience (`string`) or several (`string[]`); with an array, the check passes
 when the token's `aud` intersects the expected set.
 
+These options are type-checked against `Auth0AuthenticatorOptionsInterface` — a mistyped or wrong-typed option (e.g.
+`expectedScope` instead of `expectedScopes`) is a compile error.
+
 **Resolution precedence** (first match wins):
 
 1. The `@authenticator(Auth0Authenticator, {expectedAudience})` decorator option, when present.

--- a/packages/auth0/src/auth0.configuration-keys.ts
+++ b/packages/auth0/src/auth0.configuration-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * Typed configuration keys for `@pristine-ts/auth0`. Use these constants with `@injectConfig`
+ * for autocomplete + rename safety, instead of typing the parameter name as a string.
+ *
+ * ```ts
+ * import {injectConfig} from "@pristine-ts/common";
+ * import {Auth0ConfigurationKeys} from "@pristine-ts/auth0";
+ *
+ * constructor(@injectConfig(Auth0ConfigurationKeys.ExpectedAudience) value: string) {}
+ * ```
+ *
+ * Note: `ExpectedAudience` is optional. When neither the config nor the
+ * `PRISTINE_AUTH0_EXPECTED_AUDIENCE` environment variable is set it resolves to the empty
+ * string `""` (the configuration system cannot register `undefined`), which the
+ * authenticator treats as "no audience configured".
+ */
+export const Auth0ConfigurationKeys = {
+  IssuerDomain: "pristine.auth0.issuer.domain",
+  ExpectedAudience: "pristine.auth0.expected.audience",
+} as const;

--- a/packages/auth0/src/auth0.module.ts
+++ b/packages/auth0/src/auth0.module.ts
@@ -1,5 +1,6 @@
 import {ModuleInterface} from "@pristine-ts/common";
 import {Auth0ModuleKeyname} from "./auth0.module.keyname";
+import {Auth0ConfigurationKeys} from "./auth0.configuration-keys";
 import {HttpModule} from "@pristine-ts/http";
 import {EnvironmentVariableResolver} from "@pristine-ts/configuration";
 import {LoggingModule} from "@pristine-ts/logging";
@@ -8,6 +9,7 @@ export * from "./authenticators/authenticators";
 export * from "./interfaces/interfaces";
 
 export * from "./auth0.module.keyname";
+export * from "./auth0.configuration-keys";
 
 export const Auth0Module: ModuleInterface = {
   keyname: Auth0ModuleKeyname,
@@ -17,10 +19,33 @@ export const Auth0Module: ModuleInterface = {
      * used to retrieve the public key and validate the JWTs.
      */
     {
-      parameterName: Auth0ModuleKeyname + ".issuer.domain",
+      parameterName: Auth0ConfigurationKeys.IssuerDomain,
       isRequired: true,
       defaultResolvers: [
         new EnvironmentVariableResolver("PRISTINE_AUTH0_ISSUER_DOMAIN"),
+      ]
+    },
+    /**
+     * The audience (`aud` claim) that access tokens are expected to contain. This makes
+     * audience validation configurable centrally, so it no longer has to be passed as a
+     * per-controller `@authenticator(Auth0Authenticator, {expectedAudience})` option.
+     *
+     * It is NOT required: when neither this config nor the
+     * `PRISTINE_AUTH0_EXPECTED_AUDIENCE` environment variable is set it resolves to the
+     * empty string `""`, which the authenticator treats as "no audience configured" and
+     * skips the check — preserving the previous opt-in behavior. A per-decorator
+     * `expectedAudience` option still takes precedence when both are provided.
+     *
+     * (The configuration system requires a `defaultValue` for a non-required parameter
+     * and cannot register `undefined`, so `""` is the "unset" sentinel here rather than a
+     * real default audience.)
+     */
+    {
+      parameterName: Auth0ConfigurationKeys.ExpectedAudience,
+      isRequired: false,
+      defaultValue: "",
+      defaultResolvers: [
+        new EnvironmentVariableResolver("PRISTINE_AUTH0_EXPECTED_AUDIENCE"),
       ]
     },
   ],

--- a/packages/auth0/src/authenticators/auth0.authenticator.spec.ts
+++ b/packages/auth0/src/authenticators/auth0.authenticator.spec.ts
@@ -305,4 +305,109 @@ describe("Auth0 authenticator ", () => {
       claims: payload
     });
   });
+
+  describe("audience resolution (decorator option vs. configured audience)", () => {
+    // The token's default `aud` is the array ["example", "https://pristine-ts.com"].
+    const inToken = "https://pristine-ts.com";
+    const notInToken = "https://not-in-token.example";
+
+    // ── option only, config unset ──────────────────────────────────────────────
+    it("validates against the decorator option when no audience is configured (wrong aud throws)", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock); // config unset
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {expectedAudience: notInToken}});
+      expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim audience does not include expected audience'));
+    });
+
+    it("validates against the decorator option when no audience is configured (matching aud passes)", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock);
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {expectedAudience: inToken}});
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    // ── config only, no option ─────────────────────────────────────────────────
+    it("validates against the configured audience when no option is set (wrong config throws)", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, notInToken);
+      const token = signToken(payload, privateKey);
+      // No setContext() at all: exercises the null-safe context access as well.
+      expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim audience does not include expected audience'));
+    });
+
+    it("validates against the configured audience when no option is set (matching config passes)", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, inToken);
+      const token = signToken(payload, privateKey);
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    // ── both set → option wins (values chosen so each direction proves precedence) ─
+    it("lets the decorator option override the configured audience (option wins → throws on option mismatch)", async () => {
+      // Config MATCHES the token, option does NOT: because the option wins, this must throw.
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, inToken);
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {expectedAudience: notInToken}});
+      expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim audience does not include expected audience'));
+    });
+
+    it("lets the decorator option override the configured audience (option wins → passes on option match)", async () => {
+      // Config does NOT match the token, option does: because the option wins, this must pass.
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, notInToken);
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {expectedAudience: inToken}});
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    // ── neither set → skip (backward compatible) ───────────────────────────────
+    it("skips the audience check when neither an option nor configuration is set", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock); // config unset, no setContext
+      const token = signToken(payload, privateKey);
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    it("skips the audience check when the configured audience is the empty-string sentinel", async () => {
+      // "" is what an unset, non-required config parameter resolves to.
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, "");
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {}});
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    // ── aud as a single string vs. an array: exact membership, never substring ──
+    it("matches an exact single-string aud (aud as string)", async () => {
+      payload.aud = inToken; // a string, not an array
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, inToken);
+      const token = signToken(payload, privateKey);
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    it("does NOT substring-match a single-string aud (exact membership only)", async () => {
+      payload.aud = inToken; // "https://pristine-ts.com" as a string
+      // "pristine-ts.com" is a substring of the token's aud but not an exact match: must throw.
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, "pristine-ts.com");
+      const token = signToken(payload, privateKey);
+      expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim audience does not include expected audience'));
+    });
+
+    it("matches when the token's array aud contains the expected audience (aud as array)", async () => {
+      // payload.aud is the default array ["example", "https://pristine-ts.com"].
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock, inToken);
+      const token = signToken(payload, privateKey);
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    // ── array of expected audiences (option) → intersection with the token's aud ─
+    it("supports an array of expected audiences via the option (intersection with the token's aud)", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock);
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {expectedAudience: ["https://other.example", inToken]}});
+      expect(auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
+    });
+
+    it("throws when none of an array of expected audiences intersects the token's aud", async () => {
+      const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock);
+      const token = signToken(payload, privateKey);
+      await auth0Authenticator.setContext({options: {expectedAudience: ["https://a.example", "https://b.example"]}});
+      expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim audience does not include expected audience'));
+    });
+  });
 });

--- a/packages/auth0/src/authenticators/auth0.authenticator.ts
+++ b/packages/auth0/src/authenticators/auth0.authenticator.ts
@@ -1,12 +1,13 @@
 import {inject, injectable, singleton} from "tsyringe";
 import {createPublicKey, verify} from "crypto";
-import {HttpMethod, IdentityInterface, Request, traced} from "@pristine-ts/common";
+import {HttpMethod, IdentityInterface, injectConfig, Request, traced} from "@pristine-ts/common";
 import {TokenHeaderInterface} from "../interfaces/token-header.interface";
 import {ClaimInterface} from "../interfaces/claim.interface";
-import {AuthenticatorInterface} from "@pristine-ts/security";
+import {Auth0AuthenticatorOptionsInterface} from "../interfaces/auth0-authenticator-options.interface";
+import {AuthenticatorContextInterface, AuthenticatorInterface} from "@pristine-ts/security";
 import {HttpClientInterface, ResponseTypeEnum} from "@pristine-ts/http";
 import {LogHandlerInterface} from "@pristine-ts/logging";
-import {Auth0ModuleKeyname} from "../auth0.module.keyname";
+import {Auth0ConfigurationKeys} from "../auth0.configuration-keys";
 
 /**
  * The Auth0Authenticator is an authenticator that can be passed to the @authenticator decorator on a
@@ -37,20 +38,27 @@ export class Auth0Authenticator implements AuthenticatorInterface {
   private publicKeyUrl: string;
 
   /**
-   * The context passed by the decorator.
+   * The context passed by the decorator. Its `options` (typed as
+   * {@link Auth0AuthenticatorOptionsInterface}) carry the per-route Auth0 settings.
    * @private
    */
-  private context: any;
+  private context?: AuthenticatorContextInterface;
 
   /**
    * The Auth0 authenticator that can be passed to the @authenticator decorator.
    * @param issuerDomain The Auth0 issuer domain (without the http://).
    * @param httpClient The Http client to use to make the requests to the issuer.
    * @param logHandler The log handler to print some logs.
+   * @param configuredAudience The audience (`aud` claim) expected on tokens, configured at
+   *   the module level via `pristine.auth0.expected.audience` /
+   *   `PRISTINE_AUTH0_EXPECTED_AUDIENCE`. Optional: resolves to `""` ("unset") when not
+   *   configured, in which case the audience check is skipped unless a per-decorator
+   *   `expectedAudience` option is provided.
    */
-  constructor(@inject(`%${Auth0ModuleKeyname}.issuer.domain%`) private readonly issuerDomain: string,
+  constructor(@injectConfig(Auth0ConfigurationKeys.IssuerDomain) private readonly issuerDomain: string,
               @inject("HttpClientInterface") private readonly httpClient: HttpClientInterface,
               @inject("LogHandlerInterface") private readonly logHandler: LogHandlerInterface,
+              @injectConfig(Auth0ConfigurationKeys.ExpectedAudience) private readonly configuredAudience?: string,
   ) {
     this.auth0Issuer = this.getAuth0Issuer();
     this.publicKeyUrl = this.getPublicKeyUrl();
@@ -63,6 +71,16 @@ export class Auth0Authenticator implements AuthenticatorInterface {
   setContext(context: any): Promise<void> {
     this.context = context;
     return Promise.resolve();
+  }
+
+  /**
+   * Returns the typed options carried on the decorator context, or `undefined` when no
+   * context or options were set. Reading through this accessor keeps the `context` access
+   * null-safe and gives the option reads a concrete type.
+   * @private
+   */
+  private getOptions(): Auth0AuthenticatorOptionsInterface | undefined {
+    return this.context?.options;
   }
 
   /**
@@ -183,15 +201,39 @@ export class Auth0Authenticator implements AuthenticatorInterface {
       throw new Error('Claim issuer is invalid');
     }
 
-    // If the context has an expected audience verify that this audience is included in the token.
-    if (this.context.options?.expectedAudience && claim.aud.includes(this.context.options?.expectedAudience) === false) {
-      throw new Error('Claim audience does not include expected audience');
+    const options = this.getOptions();
+
+    // Resolve the expected audience with precedence: the per-decorator option first (a
+    // per-route override), then the module-level configured audience. The check is only
+    // enforced when an audience is actually set — with neither an option nor configuration
+    // (the config resolves to the "" sentinel when unset), the `aud` claim is not validated,
+    // preserving the previous opt-in behavior.
+    const expectedAudience = options?.expectedAudience ?? this.configuredAudience;
+
+    // Normalize to a list of non-empty audiences. This supports an array of expected
+    // audiences (the check becomes "the token's aud intersects the expected set") and drops
+    // the "" sentinel used when nothing is configured.
+    const expectedAudiences: string[] = (Array.isArray(expectedAudience) ? expectedAudience : [expectedAudience])
+      .filter((audience): audience is string => typeof audience === "string" && audience.length > 0);
+
+    if (expectedAudiences.length > 0) {
+      // `aud` per RFC 7519 can be either a single string or an array of strings (Auth0
+      // commonly issues an array, e.g. the API id plus `/userinfo`). Normalize to an array
+      // so membership is an EXACT match rather than the substring match `String.includes`
+      // would perform on a single-string `aud`.
+      const audClaim: string | string[] = claim.aud;
+      const tokenAudiences: string[] = Array.isArray(audClaim) ? audClaim : [audClaim];
+
+      if (expectedAudiences.some((audience) => tokenAudiences.includes(audience)) === false) {
+        throw new Error('Claim audience does not include expected audience');
+      }
     }
 
     // If the context has expected scopes, verify that the token has those scopes.
-    if (this.context.options?.expectedScopes) {
+    const expectedScopesOption = options?.expectedScopes;
+    if (expectedScopesOption) {
       const providedScopes: string[] = claim.scope.split(' ');
-      const expectedScopes = Array.isArray(this.context.options?.expectedScopes) === false ? [this.context.options?.expectedScopes] : this.context.options?.expectedScopes
+      const expectedScopes = Array.isArray(expectedScopesOption) ? expectedScopesOption : [expectedScopesOption];
       for (const scope of expectedScopes) {
         if (providedScopes.includes(scope) === false) {
           throw new Error("Claim does not contain the required scope: '" + scope + "'");

--- a/packages/auth0/src/authenticators/auth0.authenticator.ts
+++ b/packages/auth0/src/authenticators/auth0.authenticator.ts
@@ -20,6 +20,14 @@ import {Auth0ConfigurationKeys} from "../auth0.configuration-keys";
 export class Auth0Authenticator implements AuthenticatorInterface {
 
   /**
+   * Phantom marker consumed by the `@authenticator` decorator to type-check its options
+   * argument against {@link Auth0AuthenticatorOptionsInterface}, i.e.
+   * `@authenticator(Auth0Authenticator, {expectedAudience, expectedScopes})`. `declare`
+   * makes it type-only — it emits no runtime field.
+   */
+  declare static readonly __options?: Auth0AuthenticatorOptionsInterface;
+
+  /**
    * The cached PEMs to avoid fetching everytime.
    * @private
    */

--- a/packages/auth0/src/interfaces/auth0-authenticator-options.interface.ts
+++ b/packages/auth0/src/interfaces/auth0-authenticator-options.interface.ts
@@ -1,0 +1,24 @@
+/**
+ * The options that can be passed to the `Auth0Authenticator` through the `@authenticator`
+ * decorator, i.e. `@authenticator(Auth0Authenticator, options)`. These end up on the
+ * authenticator context as `context.options`.
+ *
+ * Both fields are optional. A field left unset means "do not enforce this check" — the
+ * audience check additionally falls back to the module-level
+ * `pristine.auth0.expected.audience` configuration when `expectedAudience` is omitted.
+ */
+export interface Auth0AuthenticatorOptionsInterface {
+  /**
+   * The audience(s) the token's `aud` claim must contain. A single string must match one
+   * of the token's audiences exactly; an array matches when the token's `aud` intersects
+   * the set. When omitted, the module-level `pristine.auth0.expected.audience`
+   * configuration is used instead (per-decorator option wins when both are set).
+   */
+  expectedAudience?: string | string[];
+
+  /**
+   * The scope(s) the token's `scope` claim must contain. A single string requires that
+   * one scope; an array requires all of them.
+   */
+  expectedScopes?: string | string[];
+}

--- a/packages/auth0/src/interfaces/interfaces.ts
+++ b/packages/auth0/src/interfaces/interfaces.ts
@@ -1,3 +1,4 @@
+export * from "./auth0-authenticator-options.interface";
 export * from "./claim.interface";
 export * from "./public-key.interface";
 export * from "./token-header.interface";

--- a/packages/security/CHANGELOG.md
+++ b/packages/security/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — @pristine-ts/security
+
+## 4.0.3
+
+- **`@authenticator` options can now be type-checked per authenticator.** The decorator is now generic and infers an
+  options type from the authenticator class via an optional phantom `static __options` marker (see the new
+  `AuthenticatorClass<TOptions>` type). `NoInfer` pins the type to the class so the `options` argument is *checked*
+  against it rather than re-inferred from the object literal.
+
+  An authenticator opts in with a single type-only line:
+
+  ```ts
+  class MyAuthenticator implements AuthenticatorInterface {
+    declare static readonly __options?: MyAuthenticatorOptionsInterface;
+    // ...
+  }
+  ```
+
+  and `@authenticator(MyAuthenticator, { ... })` is then validated at the call site. **Fully backward compatible:**
+  authenticators without the marker keep accepting any options (the parameter defaults to `any`), passing an instance
+  is unaffected, and the decorator's runtime behavior is unchanged (the phantom marker emits no runtime field).
+  `@pristine-ts/auth0` uses this for `Auth0AuthenticatorOptionsInterface`.

--- a/packages/security/src/decorators/authenticator.decorator.ts
+++ b/packages/security/src/decorators/authenticator.decorator.ts
@@ -1,5 +1,6 @@
 import {AuthenticatorInterface} from "../interfaces/authenticator.interface";
 import {AuthenticatorContextInterface} from "../interfaces/authenticator-context.interface";
+import {AuthenticatorClass} from "../types/authenticator-class.type";
 import {AuthenticatorDecoratorError} from "../errors/authenticator-decorator.error";
 import {MetadataUtil} from "@pristine-ts/common";
 
@@ -8,10 +9,20 @@ export const authenticatorMetadataKeyname = "@authenticator";
 /**
  * This decorator specifies the authenticator that should be used to authenticate a request.
  * It should be used either on a controller class or directly on a method.
+ *
+ * When the authenticator class advertises an options type (via a phantom static
+ * `__options` field, see {@link AuthenticatorClass}), `options` is type-checked against it
+ * at the call site — e.g. `@authenticator(Auth0Authenticator, {expectedAudience})` is
+ * validated against `Auth0AuthenticatorOptionsInterface`. Authenticators without that
+ * marker keep accepting any options (unchanged behavior).
+ *
+ * @typeParam TOptions The options type, inferred from the authenticator class. `NoInfer`
+ *   keeps it pinned to the class's declared type so the `options` argument is *checked*
+ *   against it rather than being used to (re)infer it.
  * @param authenticator The authenticator to use.
  * @param options Any options that will be passed on to the authenticator.
  */
-export const authenticator = (authenticator: AuthenticatorInterface | Function, options?: any) => {
+export const authenticator = <TOptions = any>(authenticator: AuthenticatorClass<TOptions> | AuthenticatorInterface, options?: NoInfer<TOptions>) => {
   return (target: any,
           propertyKey?: string,
           descriptor?: PropertyDescriptor) => {
@@ -19,7 +30,7 @@ export const authenticator = (authenticator: AuthenticatorInterface | Function, 
 
     // This is the condition to check that the authenticator is valid.
     if (!(authenticator && (
-      (typeof authenticator === 'function' && typeof authenticator.prototype.authenticate === 'function' && typeof authenticator.prototype.setContext === 'function') ||
+      (typeof authenticator === 'function' && typeof (authenticator as any).prototype.authenticate === 'function' && typeof (authenticator as any).prototype.setContext === 'function') ||
       (typeof authenticator === 'object' && typeof authenticator.authenticate === 'function' && typeof authenticator.setContext === 'function')
     ))) {
       throw new AuthenticatorDecoratorError("The authenticator isn't valid. It isn't a function or doesn't implement both the 'authenticate' and the 'setContext' methods.", authenticator, options, target, propertyKey, descriptor);

--- a/packages/security/src/security.module.ts
+++ b/packages/security/src/security.module.ts
@@ -10,6 +10,7 @@ export * from "./factories/factories";
 export * from "./guards/guards";
 export * from "./interfaces/interfaces";
 export * from "./managers/managers";
+export * from "./types/types";
 export * from "./security.module.keyname";
 
 export * from "./security.configuration-keys";

--- a/packages/security/src/types/authenticator-class.type.ts
+++ b/packages/security/src/types/authenticator-class.type.ts
@@ -1,0 +1,24 @@
+import {AuthenticatorInterface} from "../interfaces/authenticator.interface";
+
+/**
+ * A class (constructor) that produces an {@link AuthenticatorInterface}, optionally
+ * advertising the type of the options object accepted by
+ * `@authenticator(ThisClass, options)`.
+ *
+ * An authenticator opts into typed decorator options by declaring a phantom static
+ * `__options` field of the desired options type:
+ *
+ * ```ts
+ * class MyAuthenticator implements AuthenticatorInterface {
+ *   declare static readonly __options?: MyAuthenticatorOptionsInterface;
+ *   // ...
+ * }
+ * ```
+ *
+ * It is type-only (`declare` emits nothing at runtime). The `authenticator` decorator
+ * infers `TOptions` from it and type-checks the options argument at the call site.
+ * Authenticators that don't declare it leave `TOptions` at its `any` default, so their
+ * options stay unchecked — exactly the previous behavior.
+ */
+export type AuthenticatorClass<TOptions = any> =
+  (new (...args: any[]) => AuthenticatorInterface) & { readonly __options?: TOptions };

--- a/packages/security/src/types/types.ts
+++ b/packages/security/src/types/types.ts
@@ -1,0 +1,1 @@
+export * from "./authenticator-class.type";

--- a/tests/e2e/scenarios/modules/auth0/auth0-authenticator-options.type-check.e2e.ts
+++ b/tests/e2e/scenarios/modules/auth0/auth0-authenticator-options.type-check.e2e.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata";
+import {authenticator, AuthenticatorInterface} from "@pristine-ts/security";
+import {Auth0Authenticator} from "@pristine-ts/auth0";
+import {IdentityInterface, Request} from "@pristine-ts/common";
+
+/**
+ * Compile-time regression guard for the typed `@authenticator(Auth0Authenticator, …)`
+ * options. ts-jest fails a suite on an unused `@ts-expect-error` (TS2578), so this file
+ * stops compiling if the options inference ever regresses — either a valid shape starts
+ * erroring, or a bad shape stops erroring.
+ *
+ * `authenticator(...)` builds the decorator function but is never applied here, so nothing
+ * runs at runtime; the value is intentionally the compile check itself.
+ */
+
+// Valid shapes — must compile:
+authenticator(Auth0Authenticator, {expectedAudience: "https://api.example.com"});
+authenticator(Auth0Authenticator, {expectedAudience: ["https://a", "https://b"], expectedScopes: ["read:messages"]});
+authenticator(Auth0Authenticator, {expectedScopes: "read:messages"});
+authenticator(Auth0Authenticator); // options are optional
+
+// @ts-expect-error - 'expectedScope' is a typo for 'expectedScopes'
+authenticator(Auth0Authenticator, {expectedScope: ["read:messages"]});
+
+// @ts-expect-error - expectedAudience must be string | string[]
+authenticator(Auth0Authenticator, {expectedAudience: 123});
+
+// An authenticator WITHOUT the `__options` marker keeps accepting arbitrary options
+// (backward compatible — unchanged from before this feature):
+class UnmarkedAuthenticator implements AuthenticatorInterface {
+  setContext(context: any): Promise<void> {
+    return Promise.resolve();
+  }
+
+  authenticate(request: Request): Promise<IdentityInterface | undefined> {
+    return Promise.resolve(undefined);
+  }
+}
+authenticator(UnmarkedAuthenticator, {anything: true, goes: 42});
+
+describe("Auth0Authenticator @authenticator options are type-checked", () => {
+  it("is enforced at compile time (see the @ts-expect-error assertions above)", () => {
+    expect(typeof authenticator).toBe("function");
+  });
+});

--- a/tests/e2e/scenarios/modules/auth0/auth0-configured-audience.e2e.ts
+++ b/tests/e2e/scenarios/modules/auth0/auth0-configured-audience.e2e.ts
@@ -1,0 +1,233 @@
+import "reflect-metadata"
+import {container, singleton} from "tsyringe";
+import {sign} from "crypto";
+import {CoreModule, ExecutionContextKeynameEnum, Kernel} from "@pristine-ts/core";
+import {controller, NetworkingModule, route, identity} from "@pristine-ts/networking";
+import {authenticator, SecurityModule} from "@pristine-ts/security";
+import {AppModuleInterface, HttpMethod, IdentityInterface, Request, Response, tag} from "@pristine-ts/common";
+import {HttpClientInterface, HttpRequestInterface, HttpResponseInterface} from "@pristine-ts/http";
+import {Auth0Authenticator, Auth0ConfigurationKeys, Auth0Module} from "@pristine-ts/auth0";
+
+/**
+ * End-to-end coverage for the module-level ("configured") expected audience: the audience
+ * is set once via `pristine.auth0.expected.audience` (here through `kernel.start`) instead
+ * of on every `@authenticator(Auth0Authenticator, {expectedAudience})` decorator. See
+ * `auth0-protected.e2e.ts` for the decorator-option path.
+ *
+ * These drive the full request pipeline (config resolution -> DI -> Router ->
+ * AuthenticationManager -> Auth0Authenticator), so they also prove that booting the kernel
+ * with NO audience configured does not throw and simply skips the check.
+ */
+
+const privateKey = "-----BEGIN PRIVATE KEY-----\n" +
+    "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC6lQKD8qAZAL9h\n" +
+    "BrK7wMyIbPuhZJEe1eyZgaOpLP6RJlMasBfxO3L0i3yGBdTXOv8veNt5wqDtSoFz\n" +
+    "PImFWFLOJ+nNn1FcUoHoCEvUmHQrCv/2RnLwaON5126gnozQoF7sAFNPLcZ8wiTA\n" +
+    "Hl600H/N06czi6ksC2H8Nte4zRG/4vYUyiMx9+ySHj5KCElcaWSHdkGJXml/R76M\n" +
+    "PxvcsvXlrWGSMD31Ni6wJHE9rmJUtIOkQ8RlZpSb90VvZQVpJx+Vx1V4WzhVonxq\n" +
+    "K1fxTS3fEybFnKc3vzTWJgM43bRo+5b9IyL8jfYZRWCIxcI+0Xs0mp2Ust73Slnh\n" +
+    "Z+jEQrL3AgMBAAECggEBAKCm3vSXu0vr/dzgNJM/DZ1GIV+0xNOFJOSD4FQxXrvC\n" +
+    "APpQtzzJkFCJrd2ENeBgdwr8CBYOBBxs84syi8KZ6yqA6WpYDGjuzdXpFsnlvti0\n" +
+    "7vGxdRQVbBAj86gu/FZCT5jrKtBZPLd9PsGBJNCRWgnyfNwAG9jFsEfHPPVs9SR/\n" +
+    "IiNb6BcwxUcPVAF/vwrwHg/OKp7yiTHClwo7mNr07W8NAbOoioQmZ10TIyQFz92O\n" +
+    "+ezByVS8TB6RYzkrCvZSW1leIoIvqA6uaXcr1uzVdWdX0Itb8JY9x9+T83rsJxN4\n" +
+    "UNyTap7iPYAKE476F1Y+mpQzrgzM+WjqbMldtW/VhQkCgYEA3/4RIZ+f7Cfj0TTS\n" +
+    "O8d0l6+OJWcGtkjEKDmG6NJJWeQHApWxB+bIWosM2Oqff73HlftOtVELmQ8wdLJ6\n" +
+    "O/cdMrLBmOXI49WpAVNcZ8+0EVSCG9q8LLCWKqV5WMWNJKB/oMVweiarhY7UmfmW\n" +
+    "aDWSUcvDQ1uHessK3ffUIvZ6rUsCgYEA1T5sRCkX8jmZ9YdWO9gAxujmaB5PCx5l\n" +
+    "5UQ/yoWymSKEHsoTQXMI4FQGvYPvvclPfpb9Ij/HEKQ6mxpVyvfXjTWn3mx7Ho2C\n" +
+    "hPxH8b0b6EL0RPDV+yMoH3TZDpIlyQ0ho77wflWloNdrtcFW6PsNPtrzdeUVBkhG\n" +
+    "vCg+nsSQIYUCgYB4jX0a45Zmu3FZf1xG4CpYGRwf9TsfkDpCi/OYCtV/k8JSGc6V\n" +
+    "uhfK41uew2fkkHeCuSa7X0smrY4ewJAZBf6o8pxPdhyQwsWa+QqatKbtTNZZt3ff\n" +
+    "dYrcmQKeTHSSae9Gz/yhQX6++whhdnsEyxBdBZWqAvD/nZfTrzZ1OsL70QKBgQCP\n" +
+    "n1d0IOlL75fOUrS14anETqDAh4ldR8ABRpJgaOP9V838nsWRU1UrIezYP8B85tVv\n" +
+    "wWoEY0hD4RjH1ljqNzsqlHTXzeCul0jNIM2j92aQbGfw9vRoDSm85go7Uhu46es6\n" +
+    "SiPYMv828WBOLkXG7S/iob1QLlaWwJ9Doydp76HTsQKBgQDRdVYfEXDUmxHg0wzK\n" +
+    "9nmiE2jwVtwoR0JFIuPfYgfHyPlVKjMZakKWiWdXTPPs0R2gmipzve+nnITBHmHd\n" +
+    "L4Lu5XD8+E3fB+Oor6RaIZNTAlo2eRTfosEQ4bvD9ap60UTEa0dqmy3ExC3VQ/2M\nu" +
+    "XslcWkaEgIsqaNdIttT5ZRhKQ==\n" +
+    "-----END PRIVATE KEY-----\n";
+
+const tokenHeader = {
+    alg: "RS256",
+    kid: "_yqByxvM35ith2LEcJnZtEtz0SDalDw_H3Spk5i0DRg",
+    typ: "JWT"
+};
+
+const publicKeys = {
+    "keys": [{
+        "kty": "RSA",
+        "e": "AQAB",
+        "use": "sig",
+        "kid": "_yqByxvM35ith2LEcJnZtEtz0SDalDw_H3Spk5i0DRg",
+        "alg": "RS256",
+        "n": "upUCg_KgGQC_YQayu8DMiGz7oWSRHtXsmYGjqSz-kSZTGrAX8Tty9It8hgXU1zr_L3jbecKg7UqBczyJhVhSzifpzZ9RXFKB6AhL1Jh0Kwr_9kZy8GjjedduoJ6M0KBe7ABTTy3GfMIkwB5etNB_zdOnM4upLAth_DbXuM0Rv-L2FMojMffskh4-SghJXGlkh3ZBiV5pf0e-jD8b3LL15a1hkjA99TYusCRxPa5iVLSDpEPEZWaUm_dFb2UFaScflcdVeFs4VaJ8aitX8U0t3xMmxZynN7801iYDON20aPuW_SMi_I32GUVgiMXCPtF7NJqdlLLe90pZ4WfoxEKy9w"
+    }]
+}
+
+/**
+ * Signs a JWT with RS256 using native Node crypto (the auth0 package no longer depends on
+ * `jsonwebtoken`), so this scenario stays self-contained.
+ */
+const signToken = (payload: any, privateKeyPem: string, options: { keyid?: string } = {}): string => {
+    const header: { alg: string; typ: string; kid?: string } = {alg: "RS256", typ: "JWT"};
+    if (options.keyid !== undefined) {
+        header.kid = options.keyid;
+    }
+    const toBase64Url = (value: object): string => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const signingInput = toBase64Url(header) + "." + toBase64Url(payload);
+    const signature = sign("RSA-SHA256", Buffer.from(signingInput), privateKeyPem).toString("base64url");
+    return signingInput + "." + signature;
+};
+
+@tag("HttpClientInterface")
+export class MockHttpClient implements HttpClientInterface {
+    request(request: HttpRequestInterface): Promise<HttpResponseInterface> {
+        return Promise.resolve({
+            body: publicKeys,
+            request: {httpMethod: HttpMethod.Get, headers: {}, url: ""},
+            headers: {},
+            status: 200,
+        });
+    }
+}
+
+// The audience the OVERRIDE controller pins via a per-decorator option.
+const optionAudience = "https://option.example";
+// The audience configured at the module level in the "override" tests, deliberately
+// different from optionAudience so we can prove the option wins.
+const configAudienceForOverride = "https://config.example";
+
+// Relies purely on the module-level configured audience (no decorator option).
+@controller("/configured-audience")
+@singleton()
+@authenticator(Auth0Authenticator)
+class ConfiguredAudienceController {
+    @route(HttpMethod.Get, "/identity")
+    public list(@identity() identity: IdentityInterface) {
+        return identity;
+    }
+}
+
+// Pins its own audience through the decorator option; used to prove the option overrides
+// whatever is configured at the module level.
+@controller("/override-audience")
+@singleton()
+@authenticator(Auth0Authenticator, {expectedAudience: optionAudience})
+class OverrideAudienceController {
+    @route(HttpMethod.Get, "/identity")
+    public list(@identity() identity: IdentityInterface) {
+        return identity;
+    }
+}
+
+const moduleTest: AppModuleInterface = {
+    keyname: "Module",
+    importModules: [
+        CoreModule,
+        NetworkingModule,
+        Auth0Module,
+        SecurityModule,
+    ],
+    importServices: [],
+}
+
+const buildPayload = (aud: string | string[]) => ({
+    "sub": "aaaaaaaa-bbbb-cccc-dddd-example",
+    "aud": aud,
+    "iss": "https://auth0.com/",
+    "exp": (Date.now() + 3600000) / 1000,
+    "given_name": "Anaya",
+    "iat": 1500009400,
+    "email": "anaya@example.com",
+    "scope": "read:messages openid profile"
+});
+
+describe("Auth0 authenticator - module-level configured audience", () => {
+    // Make sure the environment variable never leaks in from the host/CI so the
+    // "not configured" cases are deterministic.
+    const previousAudienceEnv = process.env.PRISTINE_AUTH0_EXPECTED_AUDIENCE;
+
+    beforeEach(() => {
+        // Very important to clear the instances (incl. the singleton authenticator) between
+        // executions so each kernel picks up its own configured audience.
+        container.clearInstances();
+        delete process.env.PRISTINE_AUTH0_EXPECTED_AUDIENCE;
+    });
+
+    afterAll(() => {
+        if (previousAudienceEnv === undefined) {
+            delete process.env.PRISTINE_AUTH0_EXPECTED_AUDIENCE;
+        } else {
+            process.env.PRISTINE_AUTH0_EXPECTED_AUDIENCE = previousAudienceEnv;
+        }
+    });
+
+    const boot = async (configuration: { [key: string]: any } = {}): Promise<Kernel> => {
+        const kernel = new Kernel();
+        await kernel.start(moduleTest, {
+            [Auth0ConfigurationKeys.IssuerDomain]: "auth0.com",
+            "pristine.logging.consoleLoggerActivated": false,
+            ...configuration,
+        });
+        return kernel;
+    };
+
+    const call = async (kernel: Kernel, path: string, payload: any): Promise<Response> => {
+        const request: Request = new Request(HttpMethod.Get, "https://localhost:8080" + path, "uuid");
+        request.setHeaders({
+            "Authorization": "Bearer " + signToken(payload, privateKey, {keyid: tokenHeader.kid}),
+        });
+        return await kernel.handle(request, {keyname: ExecutionContextKeynameEnum.Jest, context: {}}) as Response;
+    };
+
+    it("authorizes when the token's aud contains the configured audience", async () => {
+        const kernel = await boot({[Auth0ConfigurationKeys.ExpectedAudience]: "https://pristine-ts.com"});
+
+        const payload = buildPayload(["example", "https://pristine-ts.com"]);
+        const response = await call(kernel, "/configured-audience/identity", payload);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({id: payload.sub, claims: payload});
+    });
+
+    it("rejects with 403 when the token's aud does not contain the configured audience", async () => {
+        const kernel = await boot({[Auth0ConfigurationKeys.ExpectedAudience]: "https://pristine-ts.com"});
+
+        const response = await call(kernel, "/configured-audience/identity", buildPayload(["example"]));
+
+        expect(response.status).toBe(403);
+        expect(response.body.code).toBe("FORBIDDEN");
+    });
+
+    it("boots and skips the audience check when NO audience is configured (backward compatible)", async () => {
+        // No pristine.auth0.expected.audience passed: it resolves to "" and must not throw at
+        // boot. With no option either, the aud claim is not validated.
+        const kernel = await boot();
+
+        const response = await call(kernel, "/configured-audience/identity", buildPayload(["some-unrelated-audience"]));
+
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBe("aaaaaaaa-bbbb-cccc-dddd-example");
+    });
+
+    it("lets a per-decorator option override the configured audience (option matches -> 200)", async () => {
+        const kernel = await boot({[Auth0ConfigurationKeys.ExpectedAudience]: configAudienceForOverride});
+
+        // Token has the OPTION audience but not the CONFIG one: since the option wins, it passes.
+        const response = await call(kernel, "/override-audience/identity", buildPayload(["example", optionAudience]));
+
+        expect(response.status).toBe(200);
+    });
+
+    it("lets a per-decorator option override the configured audience (option mismatches -> 403)", async () => {
+        const kernel = await boot({[Auth0ConfigurationKeys.ExpectedAudience]: configAudienceForOverride});
+
+        // Token has the CONFIG audience but not the OPTION one: since the option wins and does
+        // not match, the configured audience must NOT rescue it.
+        const response = await call(kernel, "/override-audience/identity", buildPayload(["example", configAudienceForOverride]));
+
+        expect(response.status).toBe(403);
+        expect(response.body.code).toBe("FORBIDDEN");
+    });
+});


### PR DESCRIPTION
## What

Makes the Auth0 access-token **audience (`aud`) check configurable centrally**, so it no longer has to be passed as an `@authenticator(Auth0Authenticator, {expectedAudience})` option on every controller. Per [RFC 9068](https://www.rfc-editor.org/rfc/rfc9068) a resource server should validate `aud`; today the check is opt-in per-decorator only and fails *open* if a route forgets it. This lets audience validation be enforced from one place while staying **100% backward compatible**.

## New configuration

| Config key | Env var | Required |
|---|---|---|
| `pristine.auth0.expected.audience` | `PRISTINE_AUTH0_EXPECTED_AUDIENCE` | No |

```ts
await kernel.start(AppModule, {
  "pristine.auth0.expected.audience": "https://api.my-service.com",
});
```

Once set, every `Auth0Authenticator`-protected route enforces it — no decorator changes needed.

## Resolution precedence (enforced only when set)

1. `@authenticator(Auth0Authenticator, {expectedAudience})` decorator option — **wins** (per-route override).
2. `pristine.auth0.expected.audience` configuration — otherwise.
3. Neither set → audience check **skipped** (exactly the previous behavior).

## Notable details

- **Array audiences supported.** `expectedAudience` now accepts `string | string[]` (check = token `aud` intersects the expected set), mirroring how `expectedScopes` already works. Single-string path unchanged.
- **Exact matching (latent bug fixed).** Replaces `claim.aud.includes(expected)`, which substring-matched when a token's `aud` was a single string (e.g. `"pristine-ts.com"` matched `"https://pristine-ts.com"`). Both string and array `aud` are normalized to a list before an exact-membership test.
- **Startup-safe.** The framework's `ConfigurationDefinition` requires a `defaultValue` for a non-required key and its parser throws on `undefined`, so the key uses `defaultValue: ""` (the same sentinel `@pristine-ts/jwt` uses). `""` is treated as "no audience configured". An E2E test boots the kernel with no audience set and confirms it neither throws nor validates `aud`.
- Types the previously-`any` authenticator options via `Auth0AuthenticatorOptionsInterface`, and adds an `Auth0ConfigurationKeys` constant.

## Testing

- **Unit** (`auth0.authenticator.spec.ts`, 32/32): option-only, config-only, both (option wins, proven both directions), neither, and `aud`-as-string-vs-array (exact, no substring).
- **E2E** (`auth0-configured-audience.e2e.ts`, new; both auth0 suites 9/9): full-kernel config-driven match / mismatch (403), boot-with-no-audience, and option-overrides-config (both directions).
- **Build**: `tsc` esm + cjs + types clean.

## Versioning

No manual `package.json` bump: lerna is fixed-mode and CI patch-bumps on merge. Added `packages/auth0/CHANGELOG.md` with a `## 4.0.3` entry, matching the concurrent http feature's convention.

## Consumer opt-in

Set `pristine.auth0.expected.audience` (or `PRISTINE_AUTH0_EXPECTED_AUDIENCE`). Nothing else. Existing per-decorator `expectedAudience` options keep working and take precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
