### PR TITLE
feat(security): differentiate 401/403 auth errors so clients know when to refresh vs. login

### DIFF
--- a/packages/auth0/src/authenticators/auth0.authenticator.spec.ts
+++ b/packages/auth0/src/authenticators/auth0.authenticator.spec.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata"
 import {Auth0Authenticator} from "./auth0.authenticator";
-import {HttpMethod, Request} from "@pristine-ts/common";
+import {HttpMethod, Request, TokenExpiredError, UnauthorizedError} from "@pristine-ts/common";
 import {sign} from "crypto";
 import {HttpClientInterface, HttpRequestInterface, HttpResponseInterface} from "@pristine-ts/http";
 import {LogHandlerInterface} from "@pristine-ts/logging";
@@ -232,18 +232,26 @@ describe("Auth0 authenticator ", () => {
     expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error("Claim does not contain the required scope: 'read:users'"));
   });
 
-  it("should not getAndVerifyClaims if expired", async () => {
+  it("should throw a TokenExpiredError (401 TOKEN_EXPIRED) when the token is expired", async () => {
     const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock);
     payload.exp = 1500000;
     const token = signToken(payload, privateKey);
-    expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error("Invalid jwt: jwt expired"));
+    expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(TokenExpiredError);
+
+    try {
+      auth0Authenticator["getAndVerifyClaims"](token, publicKey1);
+    } catch (error) {
+      expect(error).toBeInstanceOf(TokenExpiredError);
+      expect((error as TokenExpiredError).options.httpStatus).toBe(401);
+      expect((error as TokenExpiredError).options.code).toBe("TOKEN_EXPIRED");
+    }
   });
 
-  it("should not getAndVerifyClaims if auth time after", async () => {
+  it("should throw an UnauthorizedError when the auth_time is in the future", async () => {
     const auth0Authenticator = new Auth0Authenticator("auth0.com", new MockHttpClient(), logHandlerMock);
     payload.auth_time = 1500000000000;
     const token = signToken(payload, privateKey);
-    expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim is expired or invalid'));
+    expect(() => auth0Authenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(UnauthorizedError);
   });
 
   it("should not getAndVerifyClaims if issuer different", async () => {

--- a/packages/auth0/src/authenticators/auth0.authenticator.ts
+++ b/packages/auth0/src/authenticators/auth0.authenticator.ts
@@ -1,6 +1,6 @@
 import {inject, injectable, singleton} from "tsyringe";
 import {createPublicKey, verify} from "crypto";
-import {HttpMethod, IdentityInterface, injectConfig, Request, traced} from "@pristine-ts/common";
+import {ForbiddenError, HttpMethod, IdentityInterface, injectConfig, PristineError, Request, traced, TokenExpiredError, UnauthorizedError} from "@pristine-ts/common";
 import {TokenHeaderInterface} from "../interfaces/token-header.interface";
 import {ClaimInterface} from "../interfaces/claim.interface";
 import {Auth0AuthenticatorOptionsInterface} from "../interfaces/auth0-authenticator-options.interface";
@@ -196,17 +196,25 @@ export class Auth0Authenticator implements AuthenticatorInterface {
     try {
       claim = this.verifyTokenAndDecode(token, key);
     } catch (err) {
-      throw new Error("Invalid jwt: " + (err as Error).message);
+      // Preserve the typed auth errors (TokenExpiredError → refresh, UnauthorizedError →
+      // login) that verifyTokenAndDecode already raised; only opaque failures get wrapped.
+      if (err instanceof PristineError) {
+        throw err;
+      }
+      throw new UnauthorizedError("Invalid jwt: " + (err as Error).message, {cause: err as Error});
     }
 
     // Verify if the token is expired or was auth_time is invalid
     const currentSeconds = Math.floor((new Date()).valueOf() / 1000);
-    if (currentSeconds > claim.exp || currentSeconds < claim.auth_time) {
-      throw new Error('Claim is expired or invalid');
+    if (currentSeconds > claim.exp) {
+      throw new TokenExpiredError("The token has expired.");
+    }
+    if (currentSeconds < claim.auth_time) {
+      throw new UnauthorizedError("The token auth_time is invalid.");
     }
     // Verify if issuer is the auth0 issuer.
     if (claim.iss !== this.auth0Issuer) {
-      throw new Error('Claim issuer is invalid');
+      throw new UnauthorizedError('Claim issuer is invalid');
     }
 
     const options = this.getOptions();
@@ -233,7 +241,11 @@ export class Auth0Authenticator implements AuthenticatorInterface {
       const tokenAudiences: string[] = Array.isArray(audClaim) ? audClaim : [audClaim];
 
       if (expectedAudiences.some((audience) => tokenAudiences.includes(audience)) === false) {
-        throw new Error('Claim audience does not include expected audience');
+        // A token minted for a different audience is a valid credential that simply isn't
+        // meant for this resource server → authorization failure (403), consistent with the
+        // module's configured-audience behavior. (Contrast: a wrong *issuer* is an untrusted
+        // signer → 401.)
+        throw new ForbiddenError('Claim audience does not include expected audience');
       }
     }
 
@@ -244,7 +256,10 @@ export class Auth0Authenticator implements AuthenticatorInterface {
       const expectedScopes = Array.isArray(expectedScopesOption) ? expectedScopesOption : [expectedScopesOption];
       for (const scope of expectedScopes) {
         if (providedScopes.includes(scope) === false) {
-          throw new Error("Claim does not contain the required scope: '" + scope + "'");
+          // Insufficient scope is an *authorization* failure (the token is valid, the caller
+          // is authenticated, but this grant is missing) → 403, per RFC 6750
+          // `insufficient_scope`. Distinct from the invalid-token cases above which are 401.
+          throw new ForbiddenError("Claim does not contain the required scope: '" + scope + "'");
         }
       }
     }
@@ -268,7 +283,7 @@ export class Auth0Authenticator implements AuthenticatorInterface {
   private verifyTokenAndDecode(token: string, key: string): ClaimInterface {
     const tokenSections = (token || "").split(".");
     if (tokenSections.length !== 3) {
-      throw new Error("jwt malformed");
+      throw new UnauthorizedError("jwt malformed");
     }
 
     const signingInput = tokenSections[0] + "." + tokenSections[1];
@@ -277,13 +292,16 @@ export class Auth0Authenticator implements AuthenticatorInterface {
     // Auth0 signs its tokens with RS256; pinning the algorithm also guards against
     // algorithm-substitution attacks.
     if (verify("RSA-SHA256", Buffer.from(signingInput), key, signature) === false) {
-      throw new Error("invalid signature");
+      throw new UnauthorizedError("invalid signature");
     }
 
     const claim = JSON.parse(Buffer.from(tokenSections[1], "base64url").toString("utf8")) as ClaimInterface;
 
+    // An expired token is a `TokenExpiredError` (401 TOKEN_EXPIRED) so a client can try a
+    // refresh, distinct from the malformed/invalid-signature cases above (401 UNAUTHORIZED
+    // → login).
     if (claim.exp !== undefined && Math.floor(Date.now() / 1000) >= claim.exp) {
-      throw new Error("jwt expired");
+      throw new TokenExpiredError("The token has expired.");
     }
 
     return claim;

--- a/packages/aws-cognito/src/authenticators/aws-cognito.authenticator.spec.ts
+++ b/packages/aws-cognito/src/authenticators/aws-cognito.authenticator.spec.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata"
 import {AwsCognitoAuthenticator} from "./aws-cognito.authenticator";
-import {HttpMethod, Request} from "@pristine-ts/common";
+import {HttpMethod, Request, TokenExpiredError, UnauthorizedError} from "@pristine-ts/common";
 import * as jwt from "jsonwebtoken";
 import {HttpClientInterface, HttpRequestInterface, HttpResponseInterface} from "@pristine-ts/http";
 import {LogHandlerInterface} from "@pristine-ts/logging";
@@ -184,18 +184,26 @@ describe("AWS Cognito authenticator ", () => {
     expect(cognitoAuthenticator["getAndVerifyClaims"](token, publicKey1)).toEqual(payload);
   });
 
-  it("should not getAndVerifyClaims if expired", async () => {
+  it("should throw a TokenExpiredError (401 TOKEN_EXPIRED) when the token is expired", async () => {
     const cognitoAuthenticator = new AwsCognitoAuthenticator("us-east-1", "poolId", new MockHttpClient(), logHandlerMock);
     payload.exp = 1500000;
     const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'});
-    expect(() => cognitoAuthenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error("Invalid jwt: jwt expired"));
+    expect(() => cognitoAuthenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(TokenExpiredError);
+
+    try {
+      cognitoAuthenticator["getAndVerifyClaims"](token, publicKey1);
+    } catch (error) {
+      expect(error).toBeInstanceOf(TokenExpiredError);
+      expect((error as TokenExpiredError).options.httpStatus).toBe(401);
+      expect((error as TokenExpiredError).options.code).toBe("TOKEN_EXPIRED");
+    }
   });
 
-  it("should not getAndVerifyClaims if auth time after", async () => {
+  it("should throw an UnauthorizedError when the auth_time is in the future", async () => {
     const cognitoAuthenticator = new AwsCognitoAuthenticator("us-east-1", "poolId", new MockHttpClient(), logHandlerMock);
     payload.auth_time = 1500000000000;
     const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'});
-    expect(() => cognitoAuthenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(new Error('Claim is expired or invalid'));
+    expect(() => cognitoAuthenticator["getAndVerifyClaims"](token, publicKey1)).toThrow(UnauthorizedError);
   });
 
   it("should not getAndVerifyClaims if issuer different", async () => {

--- a/packages/aws-cognito/src/authenticators/aws-cognito.authenticator.ts
+++ b/packages/aws-cognito/src/authenticators/aws-cognito.authenticator.ts
@@ -1,7 +1,7 @@
 import {inject, injectable, singleton} from "tsyringe";
 import {AwsCognitoModuleKeyname} from "../aws-cognito.module.keyname";
 import * as jwt from "jsonwebtoken";
-import {HttpMethod, IdentityInterface, Request, traced} from "@pristine-ts/common";
+import {HttpMethod, IdentityInterface, Request, traced, TokenExpiredError, UnauthorizedError} from "@pristine-ts/common";
 import {TokenHeaderInterface} from "../interfaces/token-header.interface";
 import {ClaimInterface} from "../interfaces/claim.interface";
 import {AuthenticatorInterface} from "@pristine-ts/security";
@@ -170,15 +170,24 @@ export class AwsCognitoAuthenticator implements AuthenticatorInterface {
     try {
       claim = jwt.verify(token, key) as ClaimInterface;
     } catch (err) {
-      throw new Error("Invalid jwt: " + (err as Error).message);
+      // `jsonwebtoken` names the expiry error `TokenExpiredError`. Surface it as a
+      // `TokenExpiredError` (401 TOKEN_EXPIRED → refresh) distinct from any other invalid
+      // token (401 UNAUTHORIZED → login).
+      if ((err as Error)?.name === "TokenExpiredError") {
+        throw new TokenExpiredError("The token has expired.", {cause: err as Error});
+      }
+      throw new UnauthorizedError("Invalid jwt: " + (err as Error).message, {cause: err as Error});
     }
 
     const currentSeconds = Math.floor((new Date()).valueOf() / 1000);
-    if (currentSeconds > claim.exp || currentSeconds < claim.auth_time) {
-      throw new Error('Claim is expired or invalid');
+    if (currentSeconds > claim.exp) {
+      throw new TokenExpiredError("The token has expired.");
+    }
+    if (currentSeconds < claim.auth_time) {
+      throw new UnauthorizedError("The token auth_time is invalid.");
     }
     if (claim.iss !== this.cognitoIssuer) {
-      throw new Error('Claim issuer is invalid');
+      throw new UnauthorizedError('Claim issuer is invalid');
     }
 
     // We'll remove this for now as cognito authorizer only authorizes id token.

--- a/packages/common/src/errors/errors.ts
+++ b/packages/common/src/errors/errors.ts
@@ -9,6 +9,7 @@ export * from "./pristine-error-code.enum";
 export * from "./pristine-error-kind.enum";
 export * from "./pristine-error-options.interface";
 export * from "./pristine.error";
+export * from "./token-expired.error";
 export * from "./unauthorized.error";
 export * from "./usage.error";
 export * from "./validation.error";

--- a/packages/common/src/errors/pristine-error-code.enum.ts
+++ b/packages/common/src/errors/pristine-error-code.enum.ts
@@ -22,6 +22,7 @@
 export enum PristineErrorCode {
   BadRequest        = "BAD_REQUEST",
   Unauthorized      = "UNAUTHORIZED",
+  TokenExpired      = "TOKEN_EXPIRED",
   Forbidden         = "FORBIDDEN",
   NotFound          = "NOT_FOUND",
   Conflict          = "CONFLICT",

--- a/packages/common/src/errors/token-expired.error.spec.ts
+++ b/packages/common/src/errors/token-expired.error.spec.ts
@@ -1,0 +1,34 @@
+import "reflect-metadata";
+import {TokenExpiredError} from "./token-expired.error";
+import {UnauthorizedError} from "./unauthorized.error";
+import {PristineError} from "./pristine.error";
+import {PristineErrorKind} from "./pristine-error-kind.enum";
+
+describe("TokenExpiredError", () => {
+  it("should carry a 401 status and the TOKEN_EXPIRED code so a client can decide to refresh", () => {
+    const error = new TokenExpiredError();
+
+    expect(error.options.httpStatus).toBe(401);
+    expect(error.options.code).toBe("TOKEN_EXPIRED");
+    expect(error.options.kind).toBe(PristineErrorKind.UserError);
+    expect(error.message).toBe("The token has expired");
+  });
+
+  it("should remain an UnauthorizedError and a PristineError so existing 401 handling keeps working", () => {
+    const error = new TokenExpiredError();
+
+    expect(error).toBeInstanceOf(TokenExpiredError);
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error).toBeInstanceOf(PristineError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should accept a custom message and details while keeping the fixed 401/TOKEN_EXPIRED contract", () => {
+    const error = new TokenExpiredError("Session expired", {details: {tokenId: "abc"}});
+
+    expect(error.message).toBe("Session expired");
+    expect(error.options.details).toEqual({tokenId: "abc"});
+    expect(error.options.httpStatus).toBe(401);
+    expect(error.options.code).toBe("TOKEN_EXPIRED");
+  });
+});

--- a/packages/common/src/errors/token-expired.error.ts
+++ b/packages/common/src/errors/token-expired.error.ts
@@ -1,0 +1,30 @@
+import {PristineErrorCode} from "./pristine-error-code.enum";
+import {PristineErrorOptions} from "./pristine-error-options.interface";
+import {UnauthorizedError} from "./unauthorized.error";
+
+type StandardOptions = Omit<PristineErrorOptions, "httpStatus" | "exitCode" | "kind">;
+
+/**
+ * 401, `code: "TOKEN_EXPIRED"`. A refinement of {@link UnauthorizedError} for the specific
+ * case where the caller *was* authenticated but their token has expired.
+ *
+ * This distinction is the whole point: a bare 401 tells a client "you're not
+ * authenticated" but not *why*, so it can't tell "your session expired — refresh the
+ * token" from "you never authenticated — send them to login". By emitting a distinct
+ * `code` while keeping `httpStatus: 401`, a client can branch on the code:
+ *
+ * - `TOKEN_EXPIRED` → try a silent refresh, retry the request.
+ * - `UNAUTHORIZED`  → the token is missing/invalid; send the user to login.
+ * - `FORBIDDEN` (403) → authenticated but not permitted; don't retry, show "no access".
+ *
+ * Because it extends `UnauthorizedError`, `instanceof UnauthorizedError` still matches,
+ * so any code that only cares about "is this a 401" keeps working.
+ */
+export class TokenExpiredError extends UnauthorizedError {
+  constructor(message: string = "The token has expired", options: StandardOptions = {}) {
+    super(message, {
+      code: PristineErrorCode.TokenExpired,
+      ...options,
+    });
+  }
+}

--- a/packages/gcp-identity-platform/src/authenticators/identity-platform.authenticator.ts
+++ b/packages/gcp-identity-platform/src/authenticators/identity-platform.authenticator.ts
@@ -1,6 +1,6 @@
 import {inject, injectable, singleton} from "tsyringe";
 import * as jwt from "jsonwebtoken";
-import {HttpMethod, IdentityInterface, Request, traced} from "@pristine-ts/common";
+import {HttpMethod, IdentityInterface, Request, traced, TokenExpiredError, UnauthorizedError} from "@pristine-ts/common";
 import {AuthenticatorInterface} from "@pristine-ts/security";
 import {HttpClientInterface, ResponseTypeEnum} from "@pristine-ts/http";
 import {LogHandlerInterface} from "@pristine-ts/logging";
@@ -109,19 +109,28 @@ export class IdentityPlatformAuthenticator implements AuthenticatorInterface {
     try {
       claim = jwt.verify(token, cert, {algorithms: ["RS256"]}) as ClaimInterface;
     } catch (err) {
-      throw new Error("Invalid jwt: " + (err as Error).message);
+      // `jsonwebtoken` names the expiry error `TokenExpiredError`. Surface it as a
+      // `TokenExpiredError` (401 TOKEN_EXPIRED → refresh) distinct from any other invalid
+      // token (401 UNAUTHORIZED → login).
+      if ((err as Error)?.name === "TokenExpiredError") {
+        throw new TokenExpiredError("The token has expired.", {cause: err as Error});
+      }
+      throw new UnauthorizedError("Invalid jwt: " + (err as Error).message, {cause: err as Error});
     }
 
     const currentSeconds = Math.floor(Date.now() / 1000);
-    if (currentSeconds > claim.exp || currentSeconds < claim.auth_time) {
-      throw new Error("Claim is expired or invalid");
+    if (currentSeconds > claim.exp) {
+      throw new TokenExpiredError("The token has expired.");
+    }
+    if (currentSeconds < claim.auth_time) {
+      throw new UnauthorizedError("The token auth_time is invalid.");
     }
     const expectedIssuer = `https://securetoken.google.com/${this.projectId}`;
     if (claim.iss !== expectedIssuer) {
-      throw new Error("Claim issuer is invalid");
+      throw new UnauthorizedError("Claim issuer is invalid");
     }
     if (claim.aud !== this.projectId) {
-      throw new Error("Claim audience is invalid");
+      throw new UnauthorizedError("Claim audience is invalid");
     }
     return claim;
   }

--- a/packages/jwt/src/errors/invalid-jwt.error.ts
+++ b/packages/jwt/src/errors/invalid-jwt.error.ts
@@ -1,7 +1,12 @@
-import {PristineError, Request} from "@pristine-ts/common";
+import {PristineError, PristineErrorCode, Request} from "@pristine-ts/common";
 
 /**
  * This Error is thrown when you try to decode a JWT but the token is invalid.
+ *
+ * An invalid (missing signature, malformed, wrong issuer, …) token means the caller is
+ * not authenticated, so this surfaces as a `401 UNAUTHORIZED` — a client should send the
+ * user to login. An *expired* token is handled separately as a `TokenExpiredError`
+ * (`401 TOKEN_EXPIRED`) so the client can attempt a refresh instead.
  */
 export class InvalidJwtError extends PristineError {
 
@@ -15,11 +20,15 @@ export class InvalidJwtError extends PristineError {
    * @param publicKey The public key used to decode the JWT.
    */
   public constructor(message: string, previousError: Error, request: Request, token: string, algorithm: string, publicKey: string) {
-    super(message, {details: {
-      request,
-      previousError,
-      token,
-      algorithm,
-      publicKey,
-    }});  }
+    super(message, {
+      code: PristineErrorCode.Unauthorized,
+      httpStatus: 401,
+      details: {
+        request,
+        previousError,
+        token,
+        algorithm,
+        publicKey,
+      },
+    });  }
 }

--- a/packages/jwt/src/errors/jwt-authorization-header.error.ts
+++ b/packages/jwt/src/errors/jwt-authorization-header.error.ts
@@ -1,7 +1,11 @@
-import {PristineError, Request} from "@pristine-ts/common";
+import {PristineError, PristineErrorCode, Request} from "@pristine-ts/common";
 
 /**
  * This Error is thrown when there's you try to decode a JWT in a request but the AuthorizationHeader is missing.
+ *
+ * A missing (or malformed) Authorization header means the caller never presented a
+ * token, so this surfaces as a `401 UNAUTHORIZED` — the client should send the user to
+ * login rather than attempt a token refresh.
  */
 export class JwtAuthorizationHeaderError extends PristineError {
   /**
@@ -10,7 +14,11 @@ export class JwtAuthorizationHeaderError extends PristineError {
    * @param request The request that is missing the AuthorizationHeader.
    */
   public constructor(message: string, request: Request) {
-    super(message, {details: {
-      request,
-    }});  }
+    super(message, {
+      code: PristineErrorCode.Unauthorized,
+      httpStatus: 401,
+      details: {
+        request,
+      },
+    });  }
 }

--- a/packages/jwt/src/guards/jwt-protected.guard.spec.ts
+++ b/packages/jwt/src/guards/jwt-protected.guard.spec.ts
@@ -15,15 +15,16 @@ describe("JWT Protected Guard", () => {
     expect(await jwtProtectedGuard.isAuthorized(request)).toBeTruthy()
   })
 
-  it("should return false when the validateAndDecode rejects", async () => {
+  it("should propagate the error when validateAndDecode rejects, so the AuthorizerManager can surface the precise auth code instead of a generic 403", async () => {
+    const thrownError = new Error("invalid token");
     const jwtProtectedGuard = new JwtProtectedGuard({
       validateAndDecode: (request: Request): Promise<void> => {
-        return Promise.reject(new Error());
+        return Promise.reject(thrownError);
       }
     })
 
     const request = new Request(HttpMethod.Get, "https://url", "uuid")
 
-    expect(await jwtProtectedGuard.isAuthorized(request)).toBeFalsy()
+    await expect(jwtProtectedGuard.isAuthorized(request)).rejects.toBe(thrownError);
   })
 })

--- a/packages/jwt/src/guards/jwt-protected.guard.ts
+++ b/packages/jwt/src/guards/jwt-protected.guard.ts
@@ -16,15 +16,22 @@ export class JwtProtectedGuard implements GuardInterface {
 
   /**
    * Verifies if the JWT is valid and authorizes access if it is.
+   *
+   * On failure it does NOT swallow the error into a `false`: it propagates the typed error
+   * raised by the `JwtManager` (a `TokenExpiredError` → 401 TOKEN_EXPIRED, an
+   * `InvalidJwtError`/`JwtAuthorizationHeaderError` → 401 UNAUTHORIZED). The
+   * `AuthorizerManager` re-throws those typed auth errors so the client receives the
+   * precise code and can tell "refresh the token" from "log in" — a bare `false` would
+   * collapse every case into an indistinguishable 403.
    * @param request
    * @param identity
    */
   @traced()
   isAuthorized(request: Request, identity?: IdentityInterface): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
+    return new Promise<boolean>((resolve, reject) => {
       this.jwtManager.validateAndDecode(request)
         .then(value => resolve(true))
-        .catch(reason => resolve(false));
+        .catch(reason => reject(reason));
     });
   }
 

--- a/packages/jwt/src/managers/jwt.manager.spec.ts
+++ b/packages/jwt/src/managers/jwt.manager.spec.ts
@@ -1,7 +1,10 @@
 import "reflect-metadata";
 import {JwtManager} from "./jwt.manager";
-import {HttpMethod, Request} from "@pristine-ts/common";
+import {HttpMethod, Request, TokenExpiredError, UnauthorizedError} from "@pristine-ts/common";
 import {JWTKeys} from "../tests/jwt.keys";
+import {InvalidJwtError} from "../errors/invalid-jwt.error";
+import {JwtAuthorizationHeaderError} from "../errors/jwt-authorization-header.error";
+import {sign} from "jsonwebtoken";
 
 describe("JWT Manager", () => {
 
@@ -62,5 +65,59 @@ describe("JWT Manager", () => {
     const request: Request = new Request(HttpMethod.Get, "", "uuid");
 
     return expect(jwtManager.validateAndDecode(request)).rejects.toBeDefined();
+  });
+
+  it("should reject an expired JWT with a TokenExpiredError (401 TOKEN_EXPIRED) so the client can refresh", async () => {
+    const jwtManager = new JwtManager(JWTKeys.RS256.withoutPassphrase.public, "RS256");
+
+    const expiredJwt = sign({sub: "1234567890"}, JWTKeys.RS256.withoutPassphrase.private, {
+      algorithm: "RS256",
+      expiresIn: -60, // Issued expired (exp 60s in the past).
+    });
+
+    const request: Request = new Request(HttpMethod.Get, "", "uuid");
+    request.setHeaders({"Authorization": "Bearer " + expiredJwt});
+
+    await expect(jwtManager.validateAndDecode(request)).rejects.toBeInstanceOf(TokenExpiredError);
+
+    try {
+      await jwtManager.validateAndDecode(request);
+    } catch (error) {
+      expect(error).toBeInstanceOf(TokenExpiredError);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+      expect((error as TokenExpiredError).options.httpStatus).toBe(401);
+      expect((error as TokenExpiredError).options.code).toBe("TOKEN_EXPIRED");
+    }
+  });
+
+  it("should reject an invalid JWT with an InvalidJwtError mapped to 401 (login, not refresh)", async () => {
+    const jwtManager = new JwtManager(JWTKeys.RS256.withoutPassphrase.public, "RS256");
+
+    const request: Request = new Request(HttpMethod.Get, "", "uuid");
+    request.setHeaders({"Authorization": "Bearer this.is.notavalidjwt"});
+
+    try {
+      await jwtManager.validateAndDecode(request);
+      fail("Expected validateAndDecode to reject.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidJwtError);
+      expect((error as InvalidJwtError).options.httpStatus).toBe(401);
+      expect((error as InvalidJwtError).options.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  it("should reject a missing Authorization header with a JwtAuthorizationHeaderError mapped to 401", async () => {
+    const jwtManager = new JwtManager(JWTKeys.RS256.withoutPassphrase.public, "RS256");
+
+    const request: Request = new Request(HttpMethod.Get, "", "uuid");
+
+    try {
+      await jwtManager.validateAndDecode(request);
+      fail("Expected validateAndDecode to reject.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JwtAuthorizationHeaderError);
+      expect((error as JwtAuthorizationHeaderError).options.httpStatus).toBe(401);
+      expect((error as JwtAuthorizationHeaderError).options.code).toBe("UNAUTHORIZED");
+    }
   });
 });

--- a/packages/jwt/src/managers/jwt.manager.ts
+++ b/packages/jwt/src/managers/jwt.manager.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata"
 import {inject, injectable} from "tsyringe";
 import {JwtConfigurationKeys} from "../jwt.configuration-keys";
-import {injectConfig, moduleScoped, Request, tag} from "@pristine-ts/common";
+import {injectConfig, moduleScoped, Request, tag, TokenExpiredError} from "@pristine-ts/common";
 
 import {Algorithm, verify} from "jsonwebtoken"
 import {JwtAuthorizationHeaderError} from "../errors/jwt-authorization-header.error";
@@ -44,6 +44,13 @@ export class JwtManager implements JwtManagerInterface {
           algorithms: [this.algorithm],
         }, (err, decoded) => {
           if (err) {
+            // `jsonwebtoken` names the expiry error `TokenExpiredError`. Surface it as a
+            // `TokenExpiredError` (401 TOKEN_EXPIRED) so a client can attempt a refresh,
+            // versus an invalid token (401 UNAUTHORIZED) which means "log in".
+            if (err.name === "TokenExpiredError") {
+              return reject(new TokenExpiredError("The JWT has expired.", {cause: err, details: {request}}));
+            }
+
             return reject(new InvalidJwtError("The JWT is invalid.", err, request, token, this.algorithm, this.publicKey));
           }
 

--- a/packages/networking/src/router.ts
+++ b/packages/networking/src/router.ts
@@ -15,10 +15,12 @@ import {
   MetadataUtil,
   NotFoundError,
   ObjectUtil,
+  PristineError,
   Request,
   Response,
   ServiceDefinitionTagEnum,
   tag,
+  UnauthorizedError,
 } from "@pristine-ts/common";
 import {LogHandlerInterface} from "@pristine-ts/logging";
 import {AuthenticationManagerInterface, AuthorizerManagerInterface} from "@pristine-ts/security";
@@ -297,9 +299,14 @@ export class Router implements RouterInterface {
           },
         });
 
-        // Todo: check if the error is an UnauthorizedHttpError, else create one.
-        if (error instanceof ForbiddenError === false) {
-          error = new ForbiddenError("You are not allowed to access this.");
+        // Preserve any auth error the authenticator already typed (401 UNAUTHORIZED /
+        // 401 TOKEN_EXPIRED / 403 FORBIDDEN) so the client can tell "refresh the token"
+        // from "log in" from "you're not allowed". Only wrap untyped/opaque failures,
+        // and default them to 401 — a failure at the *authentication* stage means the
+        // caller isn't authenticated, which is a 401, not a 403.
+        if (error instanceof PristineError === false ||
+          (error.options.httpStatus !== 401 && error.options.httpStatus !== 403)) {
+          error = new UnauthorizedError("You are not authenticated to access this.", {cause: error as Error});
         }
 
         routerRequestExecutionSpan.end();

--- a/packages/security/src/managers/authorizer.manager.ts
+++ b/packages/security/src/managers/authorizer.manager.ts
@@ -1,6 +1,6 @@
 import {DependencyContainer, inject, injectable} from "tsyringe";
 import {LogHandlerInterface} from "@pristine-ts/logging";
-import {IdentityInterface, moduleScoped, Request, tag, traced, TracingManagerInterface} from "@pristine-ts/common";
+import {IdentityInterface, moduleScoped, PristineError, Request, tag, traced, TracingManagerInterface} from "@pristine-ts/common";
 import {AuthorizerManagerInterface} from "../interfaces/authorizer-manager.interface";
 import {GuardFactory} from "../factories/guard.factory";
 import {SecurityModuleKeyname} from "../security.module.keyname";
@@ -79,6 +79,17 @@ export class AuthorizerManager implements AuthorizerManagerInterface {
             identity,
           }
         });
+
+        // A guard that raised a *typed* auth error (401 UNAUTHORIZED / 401 TOKEN_EXPIRED /
+        // 403 FORBIDDEN) is telling us precisely *why* it denied — e.g. the JwtProtectedGuard
+        // surfacing an expired token. Propagate it so the router turns it into the exact
+        // status + code and the client can tell "refresh the token" from "log in". Any other
+        // (untyped) failure keeps denying as before: a broken guard must never accidentally
+        // authorize, and an opaque failure has no better signal than 403.
+        if (e instanceof PristineError && (e.options.httpStatus === 401 || e.options.httpStatus === 403)) {
+          throw e;
+        }
+
         isAuthorized = false;
       }
     }

--- a/tests/e2e/scenarios/modules/auth0/auth0-protected.e2e.ts
+++ b/tests/e2e/scenarios/modules/auth0/auth0-protected.e2e.ts
@@ -151,7 +151,7 @@ describe("Auth0 authenticator", () => {
         })
     })
 
-    it("should return forbidden if does not have the audience", async () => {
+    it("should return 403 FORBIDDEN if the audience does not match", async () => {
         const payload = {
             "sub": "aaaaaaaa-bbbb-cccc-dddd-example",
             "aud": [
@@ -184,10 +184,10 @@ describe("Auth0 authenticator", () => {
 
         expect(response.status).toBe(403);
         expect(response.body.code).toBe("FORBIDDEN");
-        expect(response.body.message).toBe("You are not allowed to access this.");
+        expect(response.body.message).toBe("Claim audience does not include expected audience");
     })
 
-    it("should return forbidden if does not have the scope", async () => {
+    it("should return 403 FORBIDDEN (insufficient_scope) if it does not have the scope", async () => {
         const payload = {
             "sub": "aaaaaaaa-bbbb-cccc-dddd-example",
             "aud": [
@@ -221,7 +221,7 @@ describe("Auth0 authenticator", () => {
 
         expect(response.status).toBe(403);
         expect(response.body.code).toBe("FORBIDDEN");
-        expect(response.body.message).toBe("You are not allowed to access this.");
+        expect(response.body.message).toBe("Claim does not contain the required scope: 'read:messages'");
     })
 
     it("should return forbidden if does not have the role", async () => {

--- a/tests/e2e/scenarios/modules/jwt/jwt.module.e2e.ts
+++ b/tests/e2e/scenarios/modules/jwt/jwt.module.e2e.ts
@@ -7,6 +7,7 @@ import {JWTKeys} from "./jwt.keys";
 import {AppModuleInterface, HttpMethod, Request, Response} from "@pristine-ts/common";
 import {guard} from "@pristine-ts/security";
 import {ConfigurationValidationError} from "@pristine-ts/configuration";
+import {sign} from "jsonwebtoken";
 
 describe("JWT Module instantiation in the Kernel", () => {
 
@@ -70,7 +71,7 @@ describe("JWT Module instantiation in the Kernel", () => {
         })).rejects.toThrow(new ConfigurationValidationError(["The Configuration with key: 'pristine.jwt.publicKey' is required and must be defined."]));
     })
 
-    it("should return a forbidden exception when the JWT is invalid", async () => {
+    const startJwtKernel = async () => {
         const kernel = new Kernel();
         await kernel.start({
             keyname: "jwt.test",
@@ -84,6 +85,11 @@ describe("JWT Module instantiation in the Kernel", () => {
             "pristine.jwt.publicKey": JWTKeys.RS256.withoutPassphrase.public,
             "pristine.logging.consoleLoggerActivated": false,
         });
+        return kernel;
+    };
+
+    it("should return a 401 UNAUTHORIZED (login, not refresh) when the JWT is invalid", async () => {
+        const kernel = await startJwtKernel();
 
         const request: Request = new Request(HttpMethod.Get, "http://localhost:8080/api/2.0/jwt/services", "uuid");
         request.setHeaders({
@@ -93,6 +99,39 @@ describe("JWT Module instantiation in the Kernel", () => {
         const response = await kernel.handle(request, {keyname: ExecutionContextKeynameEnum.Jest, context: {}}) as Response;
 
         expect(response instanceof Response).toBeTruthy()
-        expect(response.status).toBe(403);
+        expect(response.status).toBe(401);
+        expect((response.body as any).code).toBe("UNAUTHORIZED");
+    })
+
+    it("should return a 401 TOKEN_EXPIRED (so the client can refresh) when the JWT is expired", async () => {
+        const kernel = await startJwtKernel();
+
+        const expiredJwt = sign({sub: "1234567890"}, JWTKeys.RS256.withoutPassphrase.private, {
+            algorithm: "RS256",
+            expiresIn: -60, // Issued already expired.
+        });
+
+        const request: Request = new Request(HttpMethod.Get, "http://localhost:8080/api/2.0/jwt/services", "uuid");
+        request.setHeaders({
+            "Authorization": "Bearer " + expiredJwt,
+        });
+
+        const response = await kernel.handle(request, {keyname: ExecutionContextKeynameEnum.Jest, context: {}}) as Response;
+
+        expect(response instanceof Response).toBeTruthy()
+        expect(response.status).toBe(401);
+        expect((response.body as any).code).toBe("TOKEN_EXPIRED");
+    })
+
+    it("should return a 401 UNAUTHORIZED when the Authorization header is missing", async () => {
+        const kernel = await startJwtKernel();
+
+        const request: Request = new Request(HttpMethod.Get, "http://localhost:8080/api/2.0/jwt/services", "uuid");
+
+        const response = await kernel.handle(request, {keyname: ExecutionContextKeynameEnum.Jest, context: {}}) as Response;
+
+        expect(response instanceof Response).toBeTruthy()
+        expect(response.status).toBe(401);
+        expect((response.body as any).code).toBe("UNAUTHORIZED");
     })
 })


### PR DESCRIPTION
## Problem

Pristine collapsed every authentication failure into a single `403 FORBIDDEN`, so a client couldn't tell an **expired** token (refresh) from a **missing/invalid** one (login) from **insufficient permission** (no access). Two causes: the router rewrote all auth-stage errors to 403 (with a standing `// Todo` about it), and the authenticators / JWT guard threw untyped errors or collapsed to a boolean.

## Change

Introduce a three-way taxonomy signalled by the existing response `code` field (no response-shape change — `HttpErrorResponder` already serializes `code`):

| Situation | Error | Status | `code` | Client action |
|---|---|---|---|---|
| Token expired | `TokenExpiredError` (new) | 401 | `TOKEN_EXPIRED` | refresh |
| No / invalid / malformed token | `UnauthorizedError` | 401 | `UNAUTHORIZED` | login |
| Authenticated, lacks permission | `ForbiddenError` | 403 | `FORBIDDEN` | no access |

- **common:** add `PristineErrorCode.TokenExpired` and `TokenExpiredError` (extends `UnauthorizedError`, so existing `instanceof UnauthorizedError` handling keeps working).
- **networking/router:** preserve typed 401/403 errors from the auth stage; default untyped auth failures to 401 instead of 403.
- **security/authorizer + jwt guard:** `JwtProtectedGuard` now propagates its error and `AuthorizerManager` re-throws a guard's typed 401/403 `PristineError` (other denials still → 403), so the common JWT-guard path also emits the precise code instead of a blanket 403.
- **jwt:** `JwtManager` throws `TokenExpiredError` on expiry; `InvalidJwtError` and `JwtAuthorizationHeaderError` now map to 401.
- **auth0 / aws-cognito / gcp-identity-platform authenticators:** throw `TokenExpiredError` on expiry, `UnauthorizedError` on invalid tokens; auth0 maps missing scope → 403 (`insufficient_scope`) and audience mismatch → 403, per RFC 6750.

## Testing

All 39 packages build. Unit tests pass (common 78, security 27, networking 76, jwt 9, auth0 32, cognito 17) plus 19 e2e scenarios, including new expired→`TOKEN_EXPIRED` and missing→`UNAUTHORIZED` cases and updated auth0 audience/scope assertions. One pre-existing e2e type-check suite (`auth0-authenticator-options.type-check`) fails on unused `@ts-expect-error` directives in a file untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUFc3vvfx5ctEz1dvTy9LN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUFc3vvfx5ctEz1dvTy9LN)_